### PR TITLE
Fix readonly state.

### DIFF
--- a/src/Chart/series_manager.ts
+++ b/src/Chart/series_manager.ts
@@ -1,4 +1,5 @@
 import {
+  cloneDeep,
   filter,
   find,
   flow,
@@ -121,13 +122,13 @@ class ChartSeriesManager implements SeriesManager {
         return includes(type)(rendererTypes).toString()
       })(data)
 
-      // Find all groups of specified type
-      const groups = splitData.true
-
-      // If there are no groups, no further data processing is necessary
-      if (!groups) {
+      // If there are no series groups of this type, no further data processing is necessary
+      if (!splitData.true) {
         return data
       }
+
+      // Find all groups of specified type
+      const groups = cloneDeep(splitData.true)
 
       // Call provided `compute` method on each group
       forEach.convert({ cap: false })(compute)(groups)

--- a/src/Chart/series_manager.ts
+++ b/src/Chart/series_manager.ts
@@ -1,5 +1,4 @@
 import {
-  cloneDeep,
   filter,
   find,
   flow,
@@ -71,7 +70,7 @@ class ChartSeriesManager implements SeriesManager {
       this.assignBarIndices.bind(this),
       this.handleGroupedSeries("stacked", this.computeStack.bind(this)),
       this.handleGroupedSeries("range", this.computeRange.bind(this)),
-    )(cloneDeep(this.state.current.get("accessors").data.series(this.state.current.get("data"))))
+    )(this.state.current.get("accessors").data.series(this.state.current.get("data")))
 
     this.removeAllExcept(map(this.key)(data))
     forEach(this.updateOrCreate.bind(this))(data)

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -1,10 +1,9 @@
-import { cloneDeep } from "lodash"
-import { defaults, get, set } from "lodash/fp"
+import { cloneDeep, defaults, get, set } from "lodash/fp"
 
 export type Path = string | string[]
 
 export interface ReadOnlyState<T> {
-  get(path: Path): any
+  get(path: Path): Readonly<any>
 }
 
 export default class State<T> {
@@ -14,12 +13,13 @@ export default class State<T> {
     this.state = cloneDeep(obj)
   }
 
-  get = (path: Path): any => {
+  get = (path: Path): Readonly<any> => {
     return get([].concat((Array.isArray(path) && path) || [path]))(this.state)
   }
 
   set(path: Path, value: any) {
     this.state = set(path)(value)(this.state)
+    return value
   }
 
   merge(path: Path, value: { [key: string]: any } = {}) {
@@ -27,11 +27,7 @@ export default class State<T> {
   }
 
   readOnly(): ReadOnlyState<T> {
-    return {
-      get: (path: Path): any => {
-        return get([].concat((Array.isArray(path) && path) || [path]))(cloneDeep(this.state))
-      }
-    }
+    return { get: this.get }
   }
 
   clone(): State<T> {

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -27,7 +27,11 @@ export default class State<T> {
   }
 
   readOnly(): ReadOnlyState<T> {
-    return { get: this.get }
+    return {
+      get: (path: Path): any => {
+        return get([].concat((Array.isArray(path) && path) || [path]))(cloneDeep(this.state))
+      }
+    }
   }
 
   clone(): State<T> {

--- a/src/shared/state_handler.ts
+++ b/src/shared/state_handler.ts
@@ -44,7 +44,7 @@ export default class StateHandler<Config, Data> {
   }
 
   // Config
-  config(config?: Partial<Config>): Config {
+  config(config?: Partial<Config>) {
     if (!arguments.length) return this.state.current.get("config")
 
     const invalidOptions: string[] = reduce.convert({ cap: false })(


### PR DESCRIPTION
<blockquote class="trello-card"><a href="https://trello.com/c/N3No6O7c/287-fix-readonly-state-and-remove-need-for-deepclone-in-chart-stacking-algorithm">Fix ReadOnly state and remove need for deepClone in Chart stacking algorithm</a></blockquote>

State management for the visualizations has a `readonly` option which is passed around the various components to allow them to access saved values computed by other components, without modifying them. The `readonly` method on the state handler returned only the current state's `get` method, and not the `set` method. However, it was still possible to modify a value on the state in place once it had been retrieved via `get`. 

The state is now properly Readonly through better typings. This doesn't, however, solve the problem that the accessor functions cast data back to non-readonly. Rather than transforming every accessor function, there is now a cloneDeep in the stacking function.


### To check:

- [ ] No console errors
- [ ] No breaking visual tests
- [ ] The data in visual test #charts/case06 should not change every time the palette is changed (i.e. the stacking algorithm is stacking the raw data and not previously stacked data)

