### PR TITLE
Refactor visualization state.

### DIFF
--- a/src/Chart/axes/categorical_axis.ts
+++ b/src/Chart/axes/categorical_axis.ts
@@ -74,7 +74,7 @@ class CategoricalAxis implements AxisClass<string> {
     this.events = events
     this.position = position
     this.isXAxis = position[0] === "x"
-    this.el = insertElements(el, this.type, position, this.state.current.get("computed").canvas.drawingDims)
+    this.el = insertElements(el, this.type, position, this.state.current.getComputed().canvas.drawingDims)
     this.el.on("mouseenter", this.onComponentHover.bind(this))
   }
 
@@ -94,7 +94,7 @@ class CategoricalAxis implements AxisClass<string> {
   // Computations
   compute(): void {
     this.previous = cloneDeep(this.computed)
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     const tickWidth = this.computeTickWidth()
     const range = this.computeRange(tickWidth)
     this.computed = {
@@ -113,13 +113,13 @@ class CategoricalAxis implements AxisClass<string> {
   }
 
   private computeTickWidth(): number {
-    const barSeries = this.state.current.get("computed").series.barSeries
+    const barSeries = this.state.current.getComputed().series.barSeries
     if (isEmpty(barSeries)) {
       return 0
     }
 
-    const config = this.state.current.get("config")
-    const drawingDims = this.state.current.get("computed").canvas.drawingDims
+    const config = this.state.current.getConfig()
+    const drawingDims = this.state.current.getComputed().canvas.drawingDims
     const defaultTickWidth =
       (this.position[0] === "x"
         ? drawingDims.width / (this.data.length || 1)
@@ -152,8 +152,8 @@ class CategoricalAxis implements AxisClass<string> {
   }
 
   private computeBarPositions(defaultBarWidth: number, tickWidth: number) {
-    const config = this.state.current.get("config")
-    const computedSeries = this.state.current.get("computed").series
+    const config = this.state.current.getConfig()
+    const computedSeries = this.state.current.getComputed().series
     const indices = sortBy(identity)(uniq(values(computedSeries.barIndices)))
     let offset = -tickWidth / 2
 
@@ -173,7 +173,7 @@ class CategoricalAxis implements AxisClass<string> {
   }
 
   private computeRange(tickWidth: number): [number, number] {
-    const computed = this.state.current.get("computed")
+    const computed = this.state.current.getComputed()
     const width = tickWidth * this.data.length
     const offset = tickWidth / 2
     const margin = (axis: AxisPosition) =>
@@ -190,11 +190,11 @@ class CategoricalAxis implements AxisClass<string> {
 
   // Drawing
   draw(duration?: number): void {
-    translateAxis(this.el, this.position, this.state.current.get("computed").canvas.drawingDims)
+    translateAxis(this.el, this.position, this.state.current.getComputed().canvas.drawingDims)
     this.drawTicks(duration)
     this.drawLabels(duration)
     this.drawBorder(duration)
-    positionBackgroundRect(this.el, this.position, this.state.current.get("config").duration)
+    positionBackgroundRect(this.el, this.position, this.state.current.getConfig().duration)
     drawTitle(this.el, this.options, this.position, this.computed.range)
   }
 
@@ -246,7 +246,7 @@ class CategoricalAxis implements AxisClass<string> {
 
   // Padding added only to end of each step in d3 ordinal band scale
   private scaleWithOffset(computed: AxisComputed) {
-    const barPadding = this.state.current.get("config").innerBarSpacingCategorical
+    const barPadding = this.state.current.getConfig().innerBarSpacingCategorical
     const stepWidth = computed.scale.step()
     return (d: string) => computed.scale(d) - (computed.tickWidth ? (stepWidth * barPadding) / 2 : 0)
   }
@@ -292,20 +292,20 @@ class CategoricalAxis implements AxisClass<string> {
     let requiredMargin = computeRequiredMargin(this.el, this.options.margin, this.options.outerPadding, this.position)
 
     // Add space for flags
-    const flagAxis = this.state.current.get(["computed", "series", "axesWithFlags", this.position])
+    const flagAxis = this.state.current.getComputed().series.axesWithFlags[this.position]
     requiredMargin = requiredMargin + (flagAxis ? flagAxis.axisPadding : 0)
 
-    const computedMargins = this.state.current.get("computed").axes.margins || {}
+    const computedMargins = this.state.current.getComputed().axes.margins || {}
     if (computedMargins[this.position] === requiredMargin) {
       return
     }
     computedMargins[this.position] = requiredMargin
     this.stateWriter("margins", computedMargins)
-    translateAxis(this.el, this.position, this.state.current.get("computed").canvas.drawingDims)
+    translateAxis(this.el, this.position, this.state.current.getComputed().canvas.drawingDims)
   }
 
   private drawBorder(duration?: number): void {
-    const drawingDims = this.state.current.get("computed").canvas.drawingDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingDims
     const border = {
       x1: 0,
       x2: this.isXAxis ? drawingDims.width : 0,

--- a/src/Chart/axes/quant_axis.ts
+++ b/src/Chart/axes/quant_axis.ts
@@ -56,7 +56,7 @@ class QuantAxis implements AxisClass<number> {
     this.events = events
     this.position = position
     this.isXAxis = position[0] === "x"
-    this.el = insertElements(el, this.type, position, this.state.current.get("computed").canvas.drawingDims)
+    this.el = insertElements(el, this.type, position, this.state.current.getComputed().canvas.drawingDims)
     this.el.on("mouseenter", this.onComponentHover.bind(this))
   }
 
@@ -91,12 +91,12 @@ class QuantAxis implements AxisClass<number> {
     computed.tickSteps = this.computeTickSteps(computed)
     computed.ruleSteps = this.computeRuleSteps(computed)
     computed.labelSteps = this.computeLabelSteps(computed)
-    computed.tickFormatter = this.state.current.get("config").numberFormatter
+    computed.tickFormatter = this.state.current.getConfig().numberFormatter
     return computed
   }
 
   private computeRange(): [number, number] {
-    const computed = this.state.current.get("computed")
+    const computed = this.state.current.getComputed()
     const margin = (axis: AxisPosition) =>
       includes(axis)(computed.axes.requiredAxes) ? computed.axes.margins[axis] || 0 : 0
     return this.isXAxis
@@ -159,7 +159,7 @@ class QuantAxis implements AxisClass<number> {
 
   computeRuleTicks(steps: [number, number, number]): number[] {
     const ruleTicks = computeTicks(steps)
-    const requiredAxes = this.state.current.get("computed").axes.requiredAxes
+    const requiredAxes = this.state.current.getComputed().axes.requiredAxes
     if (includes(this.isXAxis ? "y1" : "x1")(requiredAxes)) {
       ruleTicks.shift()
     }
@@ -184,11 +184,11 @@ class QuantAxis implements AxisClass<number> {
 
   // Drawing
   draw(duration?: number): void {
-    translateAxis(this.el, this.position, this.state.current.get("computed").canvas.drawingDims)
+    translateAxis(this.el, this.position, this.state.current.getComputed().canvas.drawingDims)
     this.drawTicks(duration)
     this.drawLabels(duration)
     this.drawBorder(duration)
-    positionBackgroundRect(this.el, this.position, this.state.current.get("config").duration)
+    positionBackgroundRect(this.el, this.position, this.state.current.getConfig().duration)
     drawTitle(this.el, this.options, this.position, this.computed.range)
   }
 
@@ -243,20 +243,20 @@ class QuantAxis implements AxisClass<number> {
     let requiredMargin = computeRequiredMargin(this.el, this.options.margin, this.options.outerPadding, this.position)
 
     // Add space for flags
-    const flagAxis = this.state.current.get(["computed", "series", "axesWithFlags", this.position])
+    const flagAxis = this.state.current.getComputed().series.axesWithFlags[this.position]
     requiredMargin = requiredMargin + (flagAxis ? flagAxis.axisPadding : 0)
 
-    const computedMargins = this.state.current.get("computed").axes.margins || {}
+    const computedMargins = this.state.current.getComputed().axes.margins || {}
     if (computedMargins[this.position] === requiredMargin) {
       return
     }
     computedMargins[this.position] = requiredMargin
     this.stateWriter("margins", computedMargins)
-    translateAxis(this.el, this.position, this.state.current.get("computed").canvas.drawingDims)
+    translateAxis(this.el, this.position, this.state.current.getComputed().canvas.drawingDims)
   }
 
   private tickFormatter(): (x: number) => string {
-    const numberFormatter = this.state.current.get("config").numberFormatter
+    const numberFormatter = this.state.current.getConfig().numberFormatter
     const unitTick = last(this.computed.ticks)
     return (x: number): string => (x === unitTick && this.options.unit ? this.options.unit : numberFormatter(x))
   }
@@ -306,7 +306,7 @@ class QuantAxis implements AxisClass<number> {
   }
 
   private drawBorder(duration?: number): void {
-    const drawingDims = this.state.current.get("computed").canvas.drawingDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingDims
     const border = {
       x1: 0,
       x2: this.isXAxis ? drawingDims.width : 0,

--- a/src/Chart/axes/rules.ts
+++ b/src/Chart/axes/rules.ts
@@ -16,7 +16,7 @@ class Rules {
   }
 
   draw(): void {
-    const computedAxes = this.state.current.get("computed").axes.computed
+    const computedAxes = this.state.current.getComputed().axes.computed
     const axisComputed = computedAxes[`${this.orientation}1`] || computedAxes[`${this.orientation}2`]
     const data = clone(axisComputed.ruleTicks || axisComputed.ticks)
     const startAttributes = this.startAttributes()
@@ -27,7 +27,7 @@ class Rules {
     rules
       .exit()
       .transition()
-      .duration(this.state.current.get("config").duration)
+      .duration(this.state.current.getConfig().duration)
       .attr("x1", attributes.x1)
       .attr("x2", attributes.x2)
       .attr("y1", attributes.y1)
@@ -45,7 +45,7 @@ class Rules {
       .attr("y2", startAttributes.y2)
       .merge(rules)
       .transition()
-      .duration(this.state.current.get("config").duration)
+      .duration(this.state.current.getConfig().duration)
       .attr("x1", attributes.x1)
       .attr("x2", attributes.x2)
       .attr("y1", attributes.y1)
@@ -53,9 +53,9 @@ class Rules {
   }
 
   private startAttributes() {
-    const previousAxes = this.state.current.get("computed").axes.previous
+    const previousAxes = this.state.current.getComputed().axes.previous
     const axisPrevious = previousAxes[`${this.orientation}1`] || previousAxes[`${this.orientation}2`]
-    const drawingDims = this.state.current.get("computed").canvas.drawingDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingDims
     return {
       x1: this.yRules ? 0 : axisPrevious.scale,
       x2: this.yRules ? drawingDims.width : axisPrevious.scale,
@@ -65,9 +65,9 @@ class Rules {
   }
 
   private attributes() {
-    const computedAxes = this.state.current.get("computed").axes.computed
+    const computedAxes = this.state.current.getComputed().axes.computed
     const axisComputed = computedAxes[`${this.orientation}1`] || computedAxes[`${this.orientation}2`]
-    const drawingDims = this.state.current.get("computed").canvas.drawingDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingDims
     const scale: any = (d: any) => axisComputed.scale(d) + (axisComputed.ruleOffset || 0)
 
     return {

--- a/src/Chart/axes/time_axis.ts
+++ b/src/Chart/axes/time_axis.ts
@@ -105,7 +105,7 @@ class TimeAxis implements AxisClass<Date> {
     this.events = events
     this.position = position
     this.isXAxis = position[0] === "x"
-    this.el = insertElements(el, this.type, position, this.state.current.get("computed").canvas.drawingDims)
+    this.el = insertElements(el, this.type, position, this.state.current.getComputed().canvas.drawingDims)
     this.el.on("mouseenter", this.onComponentHover.bind(this))
   }
 
@@ -156,13 +156,13 @@ class TimeAxis implements AxisClass<Date> {
   }
 
   private computeTickWidth(ticksInDomain: Date[]): number {
-    const barSeries = this.state.current.get("computed").series.barSeries
+    const barSeries = this.state.current.getComputed().series.barSeries
     if (isEmpty(barSeries)) {
       return 0
     }
 
-    const config = this.state.current.get("config")
-    const drawingDims = this.state.current.get("computed").canvas.drawingDims
+    const config = this.state.current.getConfig()
+    const drawingDims = this.state.current.getComputed().canvas.drawingDims
     const defaultTickWidth = Math.min(drawingDims[this.isXAxis ? "width" : "height"] / ticksInDomain.length)
 
     const stacks = groupBy((s: { [key: string]: any }) => s.stackIndex || uniqueId("stackIndex"))(barSeries)
@@ -192,8 +192,8 @@ class TimeAxis implements AxisClass<Date> {
   }
 
   private computeBars(defaultBarWidth: number, tickWidth: number) {
-    const config = this.state.current.get("config")
-    const computedSeries = this.state.current.get("computed").series
+    const config = this.state.current.getConfig()
+    const computedSeries = this.state.current.getComputed().series
     const indices = sortBy(identity)(uniq(values(computedSeries.barIndices)))
     let offset = -tickWidth / 2 + config.outerBarSpacing / 2
 
@@ -217,14 +217,14 @@ class TimeAxis implements AxisClass<Date> {
   }
 
   private computeXRange(tickWidth: number, numberOfTicks: number): [number, number] {
-    const drawingDims = this.state.current.get("computed").canvas.drawingDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingDims
     const width = tickWidth * numberOfTicks
     const offset = tickWidth / 2
     return [offset, (width || drawingDims.width) - offset]
   }
 
   private computeYRange(tickWidth: number, numberOfTicks: number): [number, number] {
-    const computed = this.state.current.get("computed")
+    const computed = this.state.current.getComputed()
     const margin = (axis: AxisPosition) => {
       const isRequired: boolean = includes(axis)(computed.axes.requiredAxes)
       return isRequired ? (computed.axes.margins || {})[axis] || 0 : 0
@@ -285,11 +285,11 @@ class TimeAxis implements AxisClass<Date> {
 
   // Drawing
   draw(duration?: number): void {
-    translateAxis(this.el, this.position, this.state.current.get("computed").canvas.drawingDims)
+    translateAxis(this.el, this.position, this.state.current.getComputed().canvas.drawingDims)
     this.drawTicks(duration)
     this.drawLabels(duration)
     this.drawBorder(duration)
-    positionBackgroundRect(this.el, this.position, this.state.current.get("config").duration)
+    positionBackgroundRect(this.el, this.position, this.state.current.getConfig().duration)
     drawTitle(this.el, this.options, this.position, this.computed.range)
   }
 
@@ -346,16 +346,16 @@ class TimeAxis implements AxisClass<Date> {
     let requiredMargin = computeRequiredMargin(this.el, this.options.margin, this.options.outerPadding, this.position)
 
     // Add space for flags
-    const flagAxis = this.state.current.get(["computed", "series", "axesWithFlags", this.position])
+    const flagAxis = this.state.current.getComputed().series.axesWithFlags[this.position]
     requiredMargin = requiredMargin + (flagAxis ? flagAxis.axisPadding : 0)
 
-    const computedMargins = this.state.current.get("computed").axes.margins || {}
+    const computedMargins = this.state.current.getComputed().axes.margins || {}
     if (computedMargins[this.position] === requiredMargin) {
       return
     }
     computedMargins[this.position] = requiredMargin
     this.stateWriter("margins", computedMargins)
-    translateAxis(this.el, this.position, this.state.current.get("computed").canvas.drawingDims)
+    translateAxis(this.el, this.position, this.state.current.getComputed().canvas.drawingDims)
   }
 
   private getAttributes(): AxisAttributes {
@@ -402,7 +402,7 @@ class TimeAxis implements AxisClass<Date> {
   }
 
   private drawBorder(duration?: number): void {
-    const drawingDims = this.state.current.get("computed").canvas.drawingDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingDims
     const border = {
       x1: 0,
       x2: this.isXAxis ? drawingDims.width : 0,

--- a/src/Chart/canvas.ts
+++ b/src/Chart/canvas.ts
@@ -51,14 +51,14 @@ class ChartCanvas implements Canvas {
 
   // Lifecycle
   draw(): void {
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     const dims = this.calculateDrawingContainerDims()
     this.stateWriter("drawingContainerDims", dims)
 
     // Resize elements
     this.chartContainer
-      .attr("class", `${styles.chartContainer} ${this.state.current.get("config").uid}`)
-      .classed("hidden", this.state.current.get("config").hidden)
+      .attr("class", `${styles.chartContainer} ${this.state.current.getConfig().uid}`)
+      .classed("hidden", this.state.current.getConfig().hidden)
       .style("width", `${config.width}px`)
       .style("height", `${config.height}px`)
     this.stateWriter(["containerRect"], this.chartContainer.node().getBoundingClientRect())
@@ -160,7 +160,7 @@ class ChartCanvas implements Canvas {
   }
 
   private legendHeight(position: "top" | "bottom", float: "left" | "right"): number {
-    return get([position, float])(this.state.current.get("computed").series.dataForLegends)
+    return get([position, float])(this.state.current.getComputed().series.dataForLegends)
       ? this.elementFor(`legend-${position}-${float}`).node().offsetHeight
       : 0
   }
@@ -210,7 +210,7 @@ class ChartCanvas implements Canvas {
       memo[renderer] = series
         .append("svg:g")
         .attr("class", `series-${renderer}`)
-        .attr("clip-path", `url(#${this.state.current.get("config").uid}_${clip})`)
+        .attr("clip-path", `url(#${this.state.current.getConfig().uid}_${clip})`)
       return memo
     }, {})(seriesElements)
   }
@@ -260,16 +260,16 @@ class ChartCanvas implements Canvas {
   }
 
   private prefixedId(id: string): string {
-    return this.state.current.get("config").uid + id
+    return this.state.current.getConfig().uid + id
   }
 
   private margin(axis: AxisPosition): number {
-    const margins = this.state.current.get("computed").axes.margins || {}
+    const margins = this.state.current.getComputed().axes.margins || {}
     return margins[axis] || 0
   }
 
   private calculateDrawingContainerDims(): Dimensions {
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     return {
       height: config.height - this.totalLegendHeight(),
       width: config.width,
@@ -277,7 +277,7 @@ class ChartCanvas implements Canvas {
   }
 
   private calculateDrawingDims(): Dimensions {
-    const drawingContainerDims = this.state.current.get("computed").canvas.drawingContainerDims
+    const drawingContainerDims = this.state.current.getComputed().canvas.drawingContainerDims
     return {
       width: drawingContainerDims.width - this.margin("y1") - this.margin("y2"),
       height: drawingContainerDims.height - this.margin("x1") - this.margin("x2"),

--- a/src/Chart/facade.ts
+++ b/src/Chart/facade.ts
@@ -13,10 +13,12 @@ import defaultNumberFormatter from "../utils/number_formatter"
 
 import {
   Accessors,
+  AccessorsObject,
   AxesData,
   AxisPosition,
   ChartConfig,
   Components,
+  Computed,
   Data,
   Datum,
   Facade,
@@ -84,7 +86,7 @@ class ChartFacade implements Facade {
   private customColorAccessor: boolean = false
   private events: EventEmitter
   private series: ChartSeriesManager
-  private state: StateHandler<ChartConfig, Data>
+  private state: StateHandler<Data, ChartConfig, AccessorsObject, Computed>
 
   constructor(context: Element) {
     this.context = context
@@ -99,7 +101,7 @@ class ChartFacade implements Facade {
     return new EventEmitter()
   }
 
-  private initializeState(): StateHandler<ChartConfig, Data> {
+  private initializeState(): StateHandler<Data, ChartConfig, AccessorsObject, Computed> {
     return new StateHandler({
       data: {},
       config: defaultConfig(),

--- a/src/Chart/focus/date_focus.ts
+++ b/src/Chart/focus/date_focus.ts
@@ -24,7 +24,7 @@ class DateFocus {
 
   private onMouseMove(mousePosition: MousePosition) {
     // Identify nearest date tick and snap focus to this
-    const computedAxes = this.state.current.get("computed").axes
+    const computedAxes = this.state.current.getComputed().axes
 
     // Only render a date focus if there is a time axis
     const timeAxis = computedAxes.priorityTimeAxis
@@ -56,7 +56,7 @@ class DateFocus {
   }
 
   private focusDate(date: Date): void {
-    const computedAxes = this.state.current.get("computed").axes
+    const computedAxes = this.state.current.getComputed().axes
 
     const mainAxis = computedAxes.priorityTimeAxis
     const mainAxisComputed = computedAxes.computed[mainAxis]
@@ -91,13 +91,13 @@ class DateFocus {
     // Remove old focus (may also be a different type of focus)
     this.events.emit(Events.FOCUS.CLEAR)
     // Get focus data
-    const focusData = this.state.current.get("computed").series.dataForFocus(dates)
+    const focusData = this.state.current.getComputed().series.dataForFocus(dates)
     // Draw focus line and points
     const isVertical: boolean = dates.main.axis[0] === "x"
     const position: number = Math.round(
-      this.state.current.get(["computed", "axes", "computed", dates.main.axis, "scale"])(dates.main.date),
+      this.state.current.getComputed().axes.computed[dates.main.axis].scale(dates.main.date),
     )
-    const options = this.state.current.get("config").focusDateOptions
+    const options = this.state.current.getConfig().focusDateOptions
 
     if (includes("line")(options)) {
       this.drawLine(isVertical, position)
@@ -111,7 +111,7 @@ class DateFocus {
   }
 
   private drawLine(isVertical: boolean, position: number): void {
-    const drawingDims = this.state.current.get("computed").canvas.drawingDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingDims
     this.elGroup
       .append("svg:line")
       .attr("x1", isVertical ? position : 0)
@@ -159,8 +159,8 @@ class DateFocus {
 
     // Get label dimensions
     const labelDims = labelDimensions(this.el)
-    const drawingDimensions = this.state.current.get("computed").canvas.drawingDims
-    const offset = this.state.current.get("config").focusOffset
+    const drawingDimensions = this.state.current.getComputed().canvas.drawingDims
+    const offset = this.state.current.getConfig().focusOffset
     const labelPosition = isVertical ? "toRight" : "above"
 
     // Positioning of focus elements depends on orientation
@@ -173,7 +173,7 @@ class DateFocus {
   }
 
   private drawItemsForAxis(labels: D3Selection, data: any, date: Date, axis: AxisPosition) {
-    const formatter = this.state.current.get(["computed", "axes", "computed", axis, "tickFormatter"])
+    const formatter = this.state.current.getComputed().axes.computed[axis].tickFormatter
     this.addTitle(labels, formatter(date))
 
     const partitionedStacks = partition(get("stack"))(data)
@@ -193,13 +193,13 @@ class DateFocus {
 
   private margin(axis: AxisPosition): number {
     return (
-      this.state.current.get(["computed", "axes", "margins", axis]) ||
-      this.state.current.get(["config", axis, "margin"])
+      this.state.current.getComputed().axes.margins[axis] ||
+      this.state.current.getConfig()[axis].margin
     )
   }
 
   private getDrawingPosition() {
-    const computed = this.state.current.get("computed")
+    const computed = this.state.current.getComputed()
     const margins = computed.axes.margins
     return {
       xMin: margins.y1,

--- a/src/Chart/focus/element_focus.ts
+++ b/src/Chart/focus/element_focus.ts
@@ -21,7 +21,7 @@ class ElementFocus {
   }
 
   private onMouseOver(payload: HoverPayload) {
-    const computedAxes = this.state.current.get("computed").axes
+    const computedAxes = this.state.current.getComputed().axes
     // Only render a date focus if there isn't a time axis
     const timeAxis = computedAxes.priorityTimeAxis
     if (timeAxis) {
@@ -49,7 +49,7 @@ class ElementFocus {
 
     forEach(
       (item: { name: string; value: any }): void => {
-        const formatter = isFinite(item.value) ? this.state.current.get(["config", "numberFormatter"]) : identity
+        const formatter = isFinite(item.value) ? this.state.current.getConfig().numberFormatter : identity
         const listItem = label.append("xhtml:li")
 
         listItem
@@ -66,14 +66,14 @@ class ElementFocus {
 
     // Get label dimensions
     const labelDims = labelDimensions(this.el)
-    const drawingDimensions = this.state.current.get("computed").canvas.drawingDims
-    const offset = this.state.current.get("config").focusOffset + payload.offset
+    const drawingDimensions = this.state.current.getComputed().canvas.drawingDims
+    const offset = this.state.current.getConfig().focusOffset + payload.offset
 
     positionLabel(this.el, payload.focus, labelDims, this.getDrawingPosition(), offset, payload.position, true)
   }
 
   private getDrawingPosition() {
-    const computed = this.state.current.get("computed")
+    const computed = this.state.current.getComputed()
     const margins = computed.axes.margins
     return {
       xMin: margins.y1,

--- a/src/Chart/focus/flag_focus.ts
+++ b/src/Chart/focus/flag_focus.ts
@@ -22,7 +22,7 @@ class FlagFocus {
     // Remove old focus (may also be a different type of focus)
     this.events.emit(Events.FOCUS.CLEAR)
 
-    this.el.classed("flag", true).style("max-width", this.state.current.get("config").maxFocusLabelWidth)
+    this.el.classed("flag", true).style("max-width", this.state.current.getConfig().maxFocusLabelWidth)
 
     drawHidden(this.el, "flag")
 
@@ -49,7 +49,7 @@ class FlagFocus {
     // Get label dimensions
     const labelDims = labelDimensions(this.el)
     const drawingDimensions = this.getDrawingDimensions()
-    const offset = this.state.current.get("config").flagFocusOffset
+    const offset = this.state.current.getConfig().flagFocusOffset
 
     const labelPosition = {
       left: focusData.x + this.margin("y1") + this.focusDX(focusData, labelDims.width, offset),
@@ -61,8 +61,8 @@ class FlagFocus {
 
   private margin(axis: AxisPosition): number {
     return (
-      this.state.current.get(["computed", "axes", "margins", axis]) ||
-      this.state.current.get(["config", axis, "margin"])
+      this.state.current.getComputed().axes.margins[axis] ||
+      this.state.current.getConfig()[axis].margin
     )
   }
 
@@ -89,14 +89,14 @@ class FlagFocus {
   }
 
   private getDrawingDimensions() {
-    const computed = this.state.current.get("computed")
+    const computed = this.state.current.getComputed()
     const margins = computed.axes.margins
     return {
       xMin: margins.y1,
       xMax: margins.y1 + computed.canvas.drawingDims.width,
-      yMin: this.state.current.get("config").height - computed.canvas.drawingContainerDims.height + margins.x2,
+      yMin: this.state.current.getConfig().height - computed.canvas.drawingContainerDims.height + margins.x2,
       yMax:
-        this.state.current.get("config").height -
+        this.state.current.getConfig().height -
         computed.canvas.drawingContainerDims.height +
         margins.x2 +
         computed.canvas.drawingDims.height,

--- a/src/Chart/legend/legend.ts
+++ b/src/Chart/legend/legend.ts
@@ -35,7 +35,7 @@ class ChartLegend implements Legend {
 
   draw(): void {
     // No legend
-    if (!this.state.current.get("config").legend || !this.data) {
+    if (!this.state.current.getConfig().legend || !this.data) {
       this.remove()
       return
     }

--- a/src/Chart/legend_manager.ts
+++ b/src/Chart/legend_manager.ts
@@ -42,7 +42,7 @@ class LegendManager {
     forEach(
       (option: LegendOption): void => {
         const data: LegendDatum[] = get([option.position, option.float])(
-          this.state.current.get("computed").series.dataForLegends,
+          this.state.current.getComputed().series.dataForLegends,
         )
         this.legends[option.position][option.float].setData(data)
         this.legends[option.position][option.float].draw()
@@ -53,7 +53,7 @@ class LegendManager {
 
   // Ensure the 2 top legends (left/right) make sensible use of the available space.
   private arrangeTopLegends(): void {
-    const drawingWidth = this.state.current.get("config").width
+    const drawingWidth = this.state.current.getConfig().width
     const left = this.legends.top.left
     const right = this.legends.top.right
 

--- a/src/Chart/series/renderers/area.ts
+++ b/src/Chart/series/renderers/area.ts
@@ -93,7 +93,7 @@ class Area implements RendererClass<AreaRendererAccessors> {
     this.addMissingData()
     this.updateClipPath()
 
-    const duration = this.state.current.get("config").duration
+    const duration = this.state.current.getConfig().duration
     const data = sortBy((d: Datum) => (this.xIsBaseline ? this.x(d) : this.y(d)))(this.data)
     const area = this.el.selectAll("path.main").data([data])
 
@@ -136,9 +136,10 @@ class Area implements RendererClass<AreaRendererAccessors> {
   }
 
   private setAxisScales(): void {
-    this.xIsBaseline = this.state.current.get("computed").axes.baseline === "x"
-    this.xScale = this.state.current.get(["computed", "axes", "computed", this.series.xAxis(), "scale"])
-    this.yScale = this.state.current.get(["computed", "axes", "computed", this.series.yAxis(), "scale"])
+    this.xIsBaseline = this.state.current.getComputed().axes.baseline === "x"
+    const computedAxes = this.state.current.getComputed().axes.computed
+    this.xScale = computedAxes[this.series.xAxis()].scale
+    this.yScale = computedAxes[this.series.yAxis()].scale
     this.x0 = (d: Datum) => {
       const baseline = this.isRange ? this.xScale.domain()[0] : 0
       return this.xScale(this.xIsBaseline ? this.x(d) : hasValue(d.x0) ? d.x0 : baseline)
@@ -165,13 +166,8 @@ class Area implements RendererClass<AreaRendererAccessors> {
     if (this.closeGaps() || this.series.options.stacked) {
       return
     }
-    const ticks = this.state.current.get([
-      "computed",
-      "axes",
-      "computed",
-      this.xIsBaseline ? this.series.xAxis() : this.series.yAxis(),
-      "ticksInDomain",
-    ])
+    const axis = this.xIsBaseline ? this.series.xAxis() : this.series.yAxis()
+    const ticks = this.state.current.getComputed().axes.computed[axis].ticksInDomain
     forEach((tick: Date) => {
       if (!find((d: Datum) => (this.xIsBaseline ? this.x : this.y)(d).toString() === tick.toString())(this.data)) {
         this.data.push({
@@ -182,8 +178,7 @@ class Area implements RendererClass<AreaRendererAccessors> {
   }
 
   private updateClipPath(): void {
-    const duration = this.state.current.get("config").duration
-    const mainData = sortBy((d: Datum) => (this.xIsBaseline ? this.x(d) : this.y(d)))(this.data)
+    const duration = this.state.current.getConfig().duration
     const data = this.isRange ? [this.series.options.clipData] : []
 
     const clip = this.el.selectAll("clipPath path").data(data)

--- a/src/Chart/series/renderers/bars.ts
+++ b/src/Chart/series/renderers/bars.ts
@@ -71,7 +71,7 @@ class Bars implements RendererClass<BarsRendererAccessors> {
     this.updateClipPath()
 
     const data = filter(this.validate.bind(this))(this.data)
-    const duration = this.state.current.get("config").duration
+    const duration = this.state.current.getConfig().duration
     this.el
       .transition()
       .duration(!!this.el.attr("transform") ? duration : 0)
@@ -119,9 +119,10 @@ class Bars implements RendererClass<BarsRendererAccessors> {
   }
 
   private setAxisScales(): void {
-    this.xIsBaseline = this.state.current.get("computed").axes.baseline === "x"
-    this.xScale = this.state.current.get(["computed", "axes", "computed", this.series.xAxis(), "scale"])
-    this.yScale = this.state.current.get(["computed", "axes", "computed", this.series.yAxis(), "scale"])
+    this.xIsBaseline = this.state.current.getComputed().axes.baseline === "x"
+    const computedAxes = this.state.current.getComputed().axes.computed
+    this.xScale = computedAxes[this.series.xAxis()].scale
+    this.yScale = computedAxes[this.series.yAxis()].scale
     this.x0 = (d: Datum) => {
       const baseline = this.isRange ? this.xScale.domain()[0] : 0
       return this.xScale(
@@ -164,9 +165,9 @@ class Bars implements RendererClass<BarsRendererAccessors> {
   }
 
   defaultFocusContent(d: Datum): { name: string; value: any }[] {
-    const xTitle = this.state.current.get("accessors").data.axes(this.state.current.get("data"))[this.series.xAxis()]
+    const xTitle = this.state.current.getAccessors().data.axes(this.state.current.getData())[this.series.xAxis()]
       .title
-    const yTitle = this.state.current.get("accessors").data.axes(this.state.current.get("data"))[this.series.yAxis()]
+    const yTitle = this.state.current.getAccessors().data.axes(this.state.current.getData())[this.series.yAxis()]
       .title
     return [
       {
@@ -181,7 +182,7 @@ class Bars implements RendererClass<BarsRendererAccessors> {
   }
 
   private seriesTranslation(): string {
-    const seriesBars = this.state.current.get(["computed", "axes", "computedBars", this.series.key()])
+    const seriesBars = this.state.current.getComputed().axes.computedBars[this.series.key()]
     return this.xIsBaseline ? `translate(${seriesBars.offset}, 0)` : `translate(0, ${seriesBars.offset})`
   }
 
@@ -196,7 +197,7 @@ class Bars implements RendererClass<BarsRendererAccessors> {
   }
 
   private attributes() {
-    const barWidth = this.state.current.get(["computed", "axes", "computedBars", this.series.key(), "width"])
+    const barWidth = this.state.current.getComputed().axes.computedBars[this.series.key()].width
     return {
       x: this.x0,
       y: this.y1,
@@ -209,7 +210,7 @@ class Bars implements RendererClass<BarsRendererAccessors> {
   private onMouseOver(d: Datum, el: HTMLElement): void {
     const isNegative = this.xIsBaseline ? this.y(d) < 0 : this.x(d) < 0
     const dimensions = el.getBoundingClientRect()
-    const barOffset = this.state.current.get(["computed", "axes", "computedBars", this.series.key(), "offset"])
+    const barOffset = this.state.current.getComputed().axes.computedBars[this.series.key()].offset
 
     const focusPoint = {
       content: this.focusContent(d),
@@ -236,7 +237,7 @@ class Bars implements RendererClass<BarsRendererAccessors> {
     if (!this.isRange) {
       return
     }
-    const duration = this.state.current.get("config").duration
+    const duration = this.state.current.getConfig().duration
     let data = this.series.options.clipData
 
     // The curveStepAfter interpolation does not account for the width of the bars.
@@ -264,8 +265,8 @@ class Bars implements RendererClass<BarsRendererAccessors> {
   }
 
   private clipPath(data: any[]): string {
-    const barWidth = this.state.current.get("computed").axes.computedBars[this.series.key()].width
-    const offset = this.state.current.get("config").outerBarSpacing / 2
+    const barWidth = this.state.current.getComputed().axes.computedBars[this.series.key()].width
+    const offset = this.state.current.getConfig().outerBarSpacing / 2
     const clipPath = this.xIsBaseline ? this.xClipPath.bind(this) : this.yClipPath.bind(this)
     return clipPath(barWidth, offset)(data)
   }

--- a/src/Chart/series/renderers/flag.ts
+++ b/src/Chart/series/renderers/flag.ts
@@ -76,7 +76,7 @@ class Flag implements RendererClass<FlagRendererAccessors> {
 
     const data = this.data
     const attributes = assign({ color: this.color })(this.getAttributes())
-    const duration = this.state.current.get("config").duration
+    const duration = this.state.current.getConfig().duration
     const groups = this.el.selectAll("g").data(data)
 
     groups.exit().remove()
@@ -162,7 +162,7 @@ class Flag implements RendererClass<FlagRendererAccessors> {
   }
 
   private setAxisScales(): void {
-    this.scale = this.state.current.get(["computed", "axes", "computed", this.axis, "scale"])
+    this.scale = this.state.current.getComputed().axes.computed[this.axis].scale
   }
 
   private assignAccessors(customAccessors: Partial<FlagRendererAccessors>): void {
@@ -186,7 +186,7 @@ class Flag implements RendererClass<FlagRendererAccessors> {
     const isXAxis = this.position === "x"
     const value = isXAxis ? this.x : this.y
     const scale = this.scale
-    const drawingDims = this.state.current.get("computed").canvas.drawingDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingDims
 
     switch (this.axis) {
       case "x1":
@@ -234,7 +234,7 @@ class Flag implements RendererClass<FlagRendererAccessors> {
 
       label
         .transition()
-        .duration(this.state.current.get("config").duration)
+        .duration(this.state.current.getConfig().duration)
         .attr("x", coordinates.x)
         .attr("y", coordinates.y)
 
@@ -294,8 +294,8 @@ class Flag implements RendererClass<FlagRendererAccessors> {
     let bottom: number
     let left: any
     const margin = (axis: AxisPosition) =>
-      this.state.current.get(["computed", "axes", "margins", axis]) ||
-      this.state.current.get(["config", axis, "margin"])
+      this.state.current.getComputed().axes.margins[axis] ||
+      this.state.current.getConfig()[axis].margin
 
     return (d: Datum) => {
       const line = Math.round(attributes[this.position](d))
@@ -331,11 +331,11 @@ class Flag implements RendererClass<FlagRendererAccessors> {
 
       const focusPoint = {
         axis: this.axis,
-        axisType: this.state.current.get("accessors").data.axes(this.state.current.get("data"))[this.axis].type,
+        axisType: this.state.current.getAccessors().data.axes(this.state.current.getData())[this.axis].type,
         direction: this.direction(d),
         color: this.color(d),
         datum: this.axis[0] === "x" ? this.x(d) : this.y(d),
-        formatter: this.state.current.get(["computed", "axes", "computed", this.axis, "tickFormatter"]) || identity,
+        formatter: this.state.current.getComputed().axes.computed[this.axis].tickFormatter || identity,
         label: this.label(d),
         description: this.description(d),
         x: attributes.x ? attributes.x(d) : attributes.x2,

--- a/src/Chart/series/renderers/line.ts
+++ b/src/Chart/series/renderers/line.ts
@@ -91,7 +91,7 @@ class Line implements RendererClass<LineRendererAccessors> {
     this.addMissingData()
 
     const data = sortBy((d: Datum) => (this.xIsBaseline ? this.x(d) : this.y(d)))(this.data)
-    const duration = this.state.current.get("config").duration
+    const duration = this.state.current.getConfig().duration
 
     const line = this.el.selectAll("path").data([data])
 
@@ -143,9 +143,10 @@ class Line implements RendererClass<LineRendererAccessors> {
   }
 
   private setAxisScales(): void {
-    this.xIsBaseline = this.state.current.get("computed").axes.baseline === "x"
-    this.xScale = this.state.current.get(["computed", "axes", "computed", this.series.xAxis(), "scale"])
-    this.yScale = this.state.current.get(["computed", "axes", "computed", this.series.yAxis(), "scale"])
+    this.xIsBaseline = this.state.current.getComputed().axes.baseline === "x"
+    const computedAxes = this.state.current.getComputed().axes.computed
+    this.xScale = computedAxes[this.series.xAxis()].scale
+    this.yScale = computedAxes[this.series.yAxis()].scale
     this.adjustedX = (d: Datum) => this.xScale(this.xIsBaseline ? this.x(d) : hasValue(d.x1) ? d.x1 : this.x(d))
     this.adjustedY = (d: Datum) => this.yScale(this.xIsBaseline ? (hasValue(d.y1) ? d.y1 : this.y(d)) : this.y(d))
   }
@@ -155,7 +156,7 @@ class Line implements RendererClass<LineRendererAccessors> {
       return
     }
     if (this.xIsBaseline && !this.series.options.stacked) {
-      const ticks = this.state.current.get(["computed", "series", "dataForAxes", this.series.xAxis()])
+      const ticks = this.state.current.getComputed().series.dataForAxes[this.series.xAxis()]
       forEach((tick: any) => {
         if (!find((d: Datum) => this.x(d).toString() === tick.toString())(this.data)) {
           this.data.push({ injectedX: tick, injectedY: undefined })

--- a/src/Chart/series/renderers/symbol.ts
+++ b/src/Chart/series/renderers/symbol.ts
@@ -101,7 +101,7 @@ class Symbol implements RendererClass<SymbolRendererAccessors> {
   draw(): void {
     this.setAxisScales()
     const data = filter(this.validate.bind(this))(this.data)
-    const duration = this.state.current.get("config").duration
+    const duration = this.state.current.getConfig().duration
 
     const symbols = this.el.selectAll("path").data(data)
 
@@ -182,9 +182,9 @@ class Symbol implements RendererClass<SymbolRendererAccessors> {
   }
 
   defaultFocusContent(d: Datum): { name: string; value: any }[] {
-    const xTitle = this.state.current.get("accessors").data.axes(this.state.current.get("data"))[this.series.xAxis()]
+    const xTitle = this.state.current.getAccessors().data.axes(this.state.current.getData())[this.series.xAxis()]
       .title
-    const yTitle = this.state.current.get("accessors").data.axes(this.state.current.get("data"))[this.series.yAxis()]
+    const yTitle = this.state.current.getAccessors().data.axes(this.state.current.getData())[this.series.yAxis()]
       .title
     return [
       {
@@ -199,9 +199,10 @@ class Symbol implements RendererClass<SymbolRendererAccessors> {
   }
 
   private setAxisScales(): void {
-    this.xIsBaseline = this.state.current.get("computed").axes.baseline === "x"
-    this.xScale = this.state.current.get(["computed", "axes", "computed", this.series.xAxis(), "scale"])
-    this.yScale = this.state.current.get(["computed", "axes", "computed", this.series.yAxis(), "scale"])
+    this.xIsBaseline = this.state.current.getComputed().axes.baseline === "x"
+    const computedAxes = this.state.current.getComputed().axes.computed
+    this.xScale = computedAxes[this.series.xAxis()].scale
+    this.yScale = computedAxes[this.series.yAxis()].scale
   }
 
   private transform(d: Datum): string {

--- a/src/Chart/series/renderers/text.ts
+++ b/src/Chart/series/renderers/text.ts
@@ -70,7 +70,7 @@ class Text implements RendererClass<TextRendererAccessors> {
   draw(): void {
     this.setAxisScales()
     const data = filter(this.validate.bind(this))(this.data)
-    const duration = this.state.current.get("config").duration
+    const duration = this.state.current.getConfig().duration
     const startAttributes = this.startAttributes()
     const attributes = this.attributes()
 
@@ -132,9 +132,10 @@ class Text implements RendererClass<TextRendererAccessors> {
   }
 
   private setAxisScales(): void {
-    this.xIsBaseline = this.state.current.get("computed").axes.baseline === "x"
-    this.xScale = this.state.current.get(["computed", "axes", "computed", this.series.xAxis(), "scale"])
-    this.yScale = this.state.current.get(["computed", "axes", "computed", this.series.yAxis(), "scale"])
+    this.xIsBaseline = this.state.current.getComputed().axes.baseline === "x"
+    const computedAxes = this.state.current.getComputed().axes.computed
+    this.xScale = computedAxes[this.series.xAxis()].scale
+    this.yScale = computedAxes[this.series.yAxis()].scale
     if (!isBoolean(this.tilt)) {
       this.tilt = this.xIsBaseline
     }
@@ -145,7 +146,7 @@ class Text implements RendererClass<TextRendererAccessors> {
   }
 
   private startAttributes() {
-    const computedBars = this.state.current.get("computed").axes.computedBars
+    const computedBars = this.state.current.getComputed().axes.computedBars
     const offset = computedBars && computedBars[this.series.key()] ? computedBars[this.series.key()].width / 2 : 0
     const rotate = this.tilt ? (this.xIsBaseline ? verticalTiltAngle : horizontalTiltAngle) : 0
 
@@ -159,7 +160,7 @@ class Text implements RendererClass<TextRendererAccessors> {
   }
 
   private attributes() {
-    const computedBars = this.state.current.get("computed").axes.computedBars
+    const computedBars = this.state.current.getComputed().axes.computedBars
     const barOffset =
       computedBars && computedBars[this.series.key()]
         ? computedBars[this.series.key()].offset + computedBars[this.series.key()].width / 2

--- a/src/Chart/series/series.ts
+++ b/src/Chart/series/series.ts
@@ -60,7 +60,7 @@ class ChartSeries {
     // Assign series accessors
     forEach.convert({ cap: false })((accessor: SeriesAccessor<any>, key: string) => {
       ;(this as any)[key] = () => accessor(this.options)
-    })(this.state.current.get("accessors").series)
+    })(this.state.current.getAccessors().series)
     // Assign series-specific datum accessors
     this.x = (datumAccessors && datumAccessors.x) || defaultDatumAccessors.x
     this.y = (datumAccessors && datumAccessors.y) || defaultDatumAccessors.y
@@ -154,18 +154,12 @@ class ChartSeries {
   }
 
   valueAtFocus(focus: any): any {
-    const xIsBaseline = this.state.current.get("computed").axes.baseline === "x"
+    const xIsBaseline = this.state.current.getComputed().axes.baseline === "x"
     const baselineAccessor = (d: Datum) => (xIsBaseline ? this.x(d) || d.injectedX : this.y(d) || d.injectedY)
     const valueAccessor = xIsBaseline ? this.y : this.x
     const positionAccessor = (d: Datum) =>
       xIsBaseline ? (hasValue(d.y1) ? d.y1 : this.y(d)) : hasValue(d.x1) ? d.x1 : this.x(d)
-    const valueScale = this.state.current.get([
-      "computed",
-      "axes",
-      "computed",
-      xIsBaseline ? this.yAxis() : this.xAxis(),
-      "scale",
-    ])
+    const valueScale = this.state.current.getComputed().axes.computed[xIsBaseline ? this.yAxis() : this.xAxis()].scale
     const datum: Datum = find(
       (d: Datum): boolean => {
         return baselineAccessor(d).toString() === focus.toString()

--- a/src/Chart/series_manager.ts
+++ b/src/Chart/series_manager.ts
@@ -58,8 +58,8 @@ class ChartSeriesManager implements SeriesManager {
   }
 
   assignData(): void {
-    this.key = this.state.current.get("accessors").series.key
-    this.renderAs = this.state.current.get("accessors").series.renderAs
+    this.key = this.state.current.getAccessors().series.key
+    this.renderAs = this.state.current.getAccessors().series.renderAs
     this.prepareData()
     this.stateWriter("dataForLegends", this.dataForLegends())
     this.stateWriter("dataForAxes", this.dataForAxes())
@@ -76,11 +76,11 @@ class ChartSeriesManager implements SeriesManager {
    */
   private prepareData(): void {
     const data = flow(
-      omitBy(this.state.current.get("accessors").series.hide),
+      omitBy(this.state.current.getAccessors().series.hide),
       this.assignBarIndices.bind(this),
       this.handleGroupedSeries("stacked", this.computeStack.bind(this)),
       this.handleGroupedSeries("range", this.computeRange.bind(this)),
-    )(this.state.current.get("accessors").data.series(this.state.current.get("data")))
+    )(this.state.current.getAccessors().data.series(this.state.current.getData()))
 
     this.removeAllExcept(map(this.key)(data))
     forEach(this.updateOrCreate.bind(this))(data)

--- a/src/Chart/typings.ts
+++ b/src/Chart/typings.ts
@@ -1,4 +1,4 @@
-import { Accessor, Config, Facade, Focus, Legend } from "../shared/typings"
+import { Accessor, BaseConfig, Facade, Focus, Legend, ChartStateReadOnly, Dimensions } from "../shared/typings"
 import { DateRange } from "moment-range"
 
 export {
@@ -9,13 +9,14 @@ export {
   Dimensions,
   EventBus,
   Legend,
-  State,
   Point,
   Position,
   D3Selection,
   StateWriter,
   Canvas,
 } from "../shared/typings"
+
+export type State = ChartStateReadOnly<Data, ChartConfig, AccessorsObject, Computed>
 
 export interface AxisConfig {
   fontSize: number
@@ -34,7 +35,7 @@ export interface AxisConfig {
 
 export type FocusElement = { type: "element" | "date"; value: string | Date }
 
-export interface ChartConfig extends Config {
+export interface ChartConfig extends BaseConfig {
   flagFocusOffset: number
   focus?: FocusElement
   focusDateOptions: string[]
@@ -43,9 +44,11 @@ export interface ChartConfig extends Config {
   innerBarSpacingCategorical: number
   legend: boolean
   maxBarWidthRatio: number
+  maxFocusLabelWidth: number
   minBarWidth: number
   numberFormatter: (x: number) => string
   outerBarSpacing: number
+  palette: string[]
   showComponentFocus: boolean
   timeAxisPriority: string[]
 }
@@ -179,6 +182,8 @@ export interface SeriesAccessors {
 }
 
 // Axes
+export type AxisOrientation = "x" | "y"
+
 export type AxisPosition = "x1" | "x2" | "y1" | "y2"
 
 export type AxisType = "time" | "quant" | "categorical"
@@ -274,7 +279,6 @@ export interface AccessorsObject {
 export interface Computed {
   axes?: { [key: string]: any }
   canvas?: { [key: string]: any }
-  focus?: { [key: string]: any }
   series?: { [key: string]: any }
 }
 

--- a/src/PieChart/canvas.ts
+++ b/src/PieChart/canvas.ts
@@ -105,7 +105,7 @@ class PieChartCanvas implements Canvas {
   }
 
   private drawingContainerDims(): Dimensions {
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     return {
       height: config.height - this.elMap.legend.node().offsetHeight,
       width: config.width,
@@ -114,10 +114,10 @@ class PieChartCanvas implements Canvas {
 
   // Lifecycle
   draw(): void {
-    this.chartContainer.classed("hidden", this.state.current.get("config").hidden)
+    this.chartContainer.classed("hidden", this.state.current.getConfig().hidden)
     this.stateWriter(["containerRect"], this.chartContainer.node().getBoundingClientRect())
 
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     const dims = this.drawingContainerDims()
     this.stateWriter("drawingContainerDims", dims)
 

--- a/src/PieChart/facade.ts
+++ b/src/PieChart/facade.ts
@@ -12,8 +12,8 @@ import {
   Accessors,
   AccessorsObject,
   Components,
+  Computed,
   Data,
-  Datum,
   Facade,
   FocusElement,
   PieChartConfig,
@@ -65,7 +65,7 @@ class PieChartFacade implements Facade {
   private context: Element
   private events: EventEmitter
   private series: Series
-  private state: StateHandler<PieChartConfig, Data>
+  private state: StateHandler<Data, PieChartConfig, AccessorsObject, Computed>
 
   constructor(context: Element) {
     this.context = context
@@ -80,9 +80,9 @@ class PieChartFacade implements Facade {
     return new EventEmitter()
   }
 
-  private initializeState(): StateHandler<PieChartConfig, Data> {
+  private initializeState(): StateHandler<Data, PieChartConfig, AccessorsObject, Computed> {
     return new StateHandler({
-      data: {},
+      data: [],
       config: defaultConfig(),
       accessors: defaultAccessors(),
       computed: {},

--- a/src/PieChart/focus.ts
+++ b/src/PieChart/focus.ts
@@ -46,17 +46,17 @@ class PieChartFocus implements Focus {
       )
 
     const labelDims = labelDimensions(this.el)
-    const drawingContainerDims = this.state.current.get("computed").canvas.drawingContainerDims
+    const drawingContainerDims = this.state.current.getComputed().canvas.drawingContainerDims
 
     const drawingDimensions = {
       xMin: 0,
-      yMin: this.state.current.get("config").height - drawingContainerDims.height,
+      yMin: this.state.current.getConfig().height - drawingContainerDims.height,
       xMax: drawingContainerDims.width,
-      yMax: this.state.current.get("config").height,
+      yMax: this.state.current.getConfig().height,
     }
 
     const focus = { x: payload.focusPoint.centroid[0], y: payload.focusPoint.centroid[1] }
-    positionLabel(this.el, focus, labelDims, drawingDimensions, this.state.current.get("config").focusOffset, "above")
+    positionLabel(this.el, focus, labelDims, drawingDimensions, this.state.current.getConfig().focusOffset, "above")
   }
 
   private onElementOut(): void {

--- a/src/PieChart/legend.ts
+++ b/src/PieChart/legend.ts
@@ -32,7 +32,7 @@ class PieChartLegend implements Legend {
 
   draw(): void {
     // No legend
-    if (!this.state.current.get("config").legend) {
+    if (!this.state.current.getConfig().legend) {
       this.remove()
       return
     }
@@ -75,7 +75,7 @@ class PieChartLegend implements Legend {
   private updateComparisonLegend(): void {
     // Only needed for gauges, if comparison value is given.
     const data: LegendDatum[] = filter((d: LegendDatum): boolean => d.comparison)(
-      this.state.current.get("computed").series.dataForLegend,
+      this.state.current.getComputed().series.dataForLegend,
     )
 
     const legends = this.legend.selectAll(`div.comparison`).data(data)
@@ -99,7 +99,7 @@ class PieChartLegend implements Legend {
   }
 
   private data(): LegendDatum[] {
-    return filter((d: LegendDatum) => !d.comparison)(this.state.current.get("computed").series.dataForLegend)
+    return filter((d: LegendDatum) => !d.comparison)(this.state.current.getComputed().series.dataForLegend)
   }
 
   private onComponentHover(d: LegendDatum, el: HTMLElement): void {
@@ -122,7 +122,7 @@ class PieChartLegend implements Legend {
 
   private updateDimensions(): void {
     const legendNode = this.legend.node()
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     const h = config.height
     const lh = roundedUpHeight(legendNode) + heightMargin(legendNode)
 

--- a/src/PieChart/renderers/donut.ts
+++ b/src/PieChart/renderers/donut.ts
@@ -77,11 +77,11 @@ class Donut implements Renderer {
   }
 
   private updateDraw(): void {
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     const duration = config.duration
     const maxTotalFontSize = config.maxTotalFontSize
     const minTotalFontSize = config.minTotalFontSize
-    const drawingDims = this.state.current.get("computed").canvas.drawingContainerDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingContainerDims
 
     // Remove focus before updating chart
     this.events.emit(Events.FOCUS.ELEMENT.OUT)
@@ -197,7 +197,7 @@ class Donut implements Renderer {
   }
 
   private computeArcs(computed: ComputedInitial): ComputedArcs {
-    const drawingDims = this.state.current.get("computed").canvas.drawingContainerDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingContainerDims
     const r = this.computeOuterRadius(drawingDims)
     const rInner = this.computeInnerRadius(r)
     const rHover = r + 1
@@ -216,12 +216,12 @@ class Donut implements Renderer {
   }
 
   private computeOuterRadius(drawingDims: Dimensions): number {
-    const outerBorderMargin = this.state.current.get("config").outerBorderMargin
+    const outerBorderMargin = this.state.current.getConfig().outerBorderMargin
     return Math.min(drawingDims.width, drawingDims.height) / 2 - outerBorderMargin
   }
 
   private computeInnerRadius(outerRadius: number): number {
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     const width = outerRadius - config.minInnerRadius
     // If there isn't enough space, don't render inner circle
     return width < config.minWidth ? 0 : outerRadius - Math.min(width, config.maxWidth)

--- a/src/PieChart/renderers/gauge.ts
+++ b/src/PieChart/renderers/gauge.ts
@@ -79,11 +79,11 @@ class Gauge implements Renderer {
   }
 
   private updateDraw(): void {
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     const duration = config.duration
     const maxTotalFontSize = config.maxTotalFontSize
     const minTotalFontSize = config.minTotalFontSize
-    const drawingDims = this.state.current.get("computed").canvas.drawingContainerDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingContainerDims
 
     // Remove focus before updating chart
     this.events.emit(Events.FOCUS.ELEMENT.OUT)
@@ -249,7 +249,7 @@ class Gauge implements Renderer {
     enter
       .merge(comparison)
       .transition()
-      .duration(this.state.current.get("config").duration)
+      .duration(this.state.current.getConfig().duration)
       .select("path")
       .attrTween("d", this.lineTween.bind(this))
   }
@@ -323,8 +323,8 @@ class Gauge implements Renderer {
   }
 
   private computeArcs(computed: ComputedInitial): ComputedArcs {
-    const drawingDims = this.state.current.get("computed").canvas.drawingContainerDims
-    const outerBorderMargin = this.state.current.get("config").outerBorderMargin
+    const drawingDims = this.state.current.getComputed().canvas.drawingContainerDims
+    const outerBorderMargin = this.state.current.getConfig().outerBorderMargin
     const r = this.computeOuterRadius(drawingDims, outerBorderMargin)
     const rInner = this.computeInnerRadius(r)
     const rHover = r + 1
@@ -349,7 +349,7 @@ class Gauge implements Renderer {
   }
 
   private computeInnerRadius(outerRadius: any): number {
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     const width = outerRadius - config.minInnerRadius
     // If there isn't enough space, don't render inner circle
     return width < config.minWidth ? 0 : outerRadius - Math.min(width, config.maxWidth)

--- a/src/PieChart/renderers/polar.ts
+++ b/src/PieChart/renderers/polar.ts
@@ -78,11 +78,11 @@ class Polar implements Renderer {
   }
 
   private updateDraw(): void {
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     const duration = config.duration
     const maxTotalFontSize = config.maxTotalFontSize
     const minTotalFontSize = config.minTotalFontSize
-    const drawingDims = this.state.current.get("computed").canvas.drawingContainerDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingContainerDims
 
     // Remove focus before updating chart
     this.events.emit(Events.FOCUS.ELEMENT.OUT)
@@ -129,11 +129,11 @@ class Polar implements Renderer {
     this.el.attr("transform", Utils.translateString(this.currentTranslation))
 
     const current = (this.el.node() as any).getBoundingClientRect()
-    const drawing = this.state.current.get("computed").canvas.drawingContainerRect
+    const drawing = this.state.current.getComputed().canvas.drawingContainerRect
     if (current.width === 0 && current.height === 0) {
       return
     }
-    const margin = this.state.current.get("config").outerBorderMargin
+    const margin = this.state.current.getConfig().outerBorderMargin
 
     const scale: number = Math.min(
       (drawing.width - 2 * margin) / current.width,
@@ -144,7 +144,7 @@ class Polar implements Renderer {
     this.el.selectAll("path").attr("d", this.computed.arc)
 
     const newCurrent = (this.el.node() as any).getBoundingClientRect()
-    const topOffset = this.state.current.get("computed").canvas.legend.node().offsetHeight
+    const topOffset = this.state.current.getComputed().canvas.legend.node().offsetHeight
 
     this.currentTranslation = [
       (drawing.width - newCurrent.width) / 2 + drawing.left - newCurrent.left,
@@ -219,7 +219,7 @@ class Polar implements Renderer {
   }
 
   private computeArcs(computed: Partial<ComputedData>): ComputedArcs {
-    const drawingDims = this.state.current.get("computed").canvas.drawingContainerDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingContainerDims
     const r = this.computeOuterRadius(drawingDims)
     const rInner = this.computeInnerRadius(computed.data, r)
     const rHover = this.hoverOuterRadius(r)
@@ -243,15 +243,15 @@ class Polar implements Renderer {
     const domainMax = max(map((datum: Datum) => this.value(datum))(this.data))
     const scale = d3ScaleSqrt()
       .range([
-        this.state.current.get("config").minInnerRadius,
-        Math.min(drawingDims.width, drawingDims.height) / 2 - this.state.current.get("config").outerBorderMargin,
+        this.state.current.getConfig().minInnerRadius,
+        Math.min(drawingDims.width, drawingDims.height) / 2 - this.state.current.getConfig().outerBorderMargin,
       ])
       .domain([0, domainMax])
     return (d: Datum): number => scale(this.value(d)) * scaleFactor
   }
 
   private computeInnerRadius(data: ComputedDatum[], outerRadius: (d: Datum) => number): number {
-    const options = this.state.current.get("config")
+    const options = this.state.current.getConfig()
     const minWidth = this.minSegmentWidth || MIN_SEGMENT_WIDTH
     const maxWidth = options.maxWidth
     const minOuterRadius = min(map(outerRadius)(data))

--- a/src/PieChart/renderers/renderer_utils.ts
+++ b/src/PieChart/renderers/renderer_utils.ts
@@ -32,7 +32,7 @@ export const assignOptions = (ctx: Renderer, options: { [key: string]: any }): v
 }
 
 export const defaultAccessors = (ctx: Renderer): RendererAccessors => {
-  const assignColor = colorAssigner(ctx.state.current.get("config").palette)
+  const assignColor = colorAssigner(ctx.state.current.getConfig().palette)
   return {
     value: (d: Datum) => d.value,
     key: (d: Datum) => d.key,

--- a/src/PieChart/series.ts
+++ b/src/PieChart/series.ts
@@ -34,7 +34,7 @@ class Series {
   }
 
   assignData(): void {
-    this.attributes = this.state.current.get("data")
+    this.attributes = this.state.current.getData()
     this.assignAccessors()
     this.updateRenderer()
     this.prepareData()
@@ -48,13 +48,13 @@ class Series {
           return this.renderer.key(datum) && this.renderer.key(datum).length > 0 && this.renderer.value(datum) > 0
         },
       ),
-    )(this.state.current.get("accessors").data.data(this.attributes))
+    )(this.state.current.getAccessors().data.data(this.attributes))
     this.renderer.setData(this.data)
     this.stateWriter("data", this.data)
   }
 
   private assignAccessors(): void {
-    const accessors = this.state.current.get("accessors").series
+    const accessors = this.state.current.getAccessors().series
     forEach.convert({ cap: false })((accessor: any, key: string) => {
       ;(this as any)[key] = () => accessor(this.attributes)
     })(accessors)

--- a/src/PieChart/typings.ts
+++ b/src/PieChart/typings.ts
@@ -1,7 +1,7 @@
 // Type definitions for the Contiamo Process Flow visualization
 import * as d3 from "d3-selection"
 import { Arc, Pie, PieArcDatum } from "d3-shape"
-import { Accessor, Config, Facade, Focus, Legend, State } from "../shared/typings"
+import { Accessor, BaseConfig, Facade, Focus, Legend, ChartStateReadOnly } from "../shared/typings"
 
 export {
   Accessor,
@@ -15,13 +15,14 @@ export {
   Legend,
   Point,
   Position,
-  State,
   StateWriter,
 } from "../shared/typings"
 
+export type State = ChartStateReadOnly<Data, PieChartConfig, AccessorsObject, Computed>
+
 export type FocusElement = string
 
-export interface PieChartConfig extends Config {
+export interface PieChartConfig extends BaseConfig {
   displayPercentages: boolean
   focusElement?: FocusElement
   focusOffset: number
@@ -78,9 +79,9 @@ export interface RendererAccessors {
 }
 
 export interface Computed {
-  canvas: { [key: string]: any }
-  focus: { [key: string]: any }
-  series: { [key: string]: any }
+  canvas?: { [key: string]: any }
+  focus?: { [key: string]: any }
+  series?: { [key: string]: any }
 }
 
 export interface DatumInfo {
@@ -139,7 +140,7 @@ export interface Renderer {
   key: Accessor<Datum | ComputedDatum, string>
   remove: () => void
   setData: (data: Datum[]) => void
-  state: State
+  state: ChartStateReadOnly<Data, PieChartConfig, AccessorsObject, Computed>
   type: "donut" | "gauge" | "polar"
   updateOptions: (options: { [key: string]: any }) => void
   value: Accessor<Datum | ComputedDatum, number>

--- a/src/ProcessFlow/canvas.ts
+++ b/src/ProcessFlow/canvas.ts
@@ -74,7 +74,7 @@ class ProcessFlowCanvas implements Canvas {
 
   // Lifecycle
   draw(): void {
-    this.chartContainer.classed("hidden", this.state.current.get("config").hidden)
+    this.chartContainer.classed("hidden", this.state.current.getConfig().hidden)
     this.stateWriter(["containerRect"], this.chartContainer.node().getBoundingClientRect())
   }
 

--- a/src/ProcessFlow/data_handler.ts
+++ b/src/ProcessFlow/data_handler.ts
@@ -21,8 +21,8 @@ class DataHandler {
   }
 
   prepareData(): Data {
-    const data = this.state.current.get("data")
-    const accessors = this.state.current.get("accessors")
+    const data = this.state.current.getData()
+    const accessors = this.state.current.getAccessors()
     this.journeys = accessors.data.journeys(data)
     this.initializeNodes(accessors.data.nodes(data))
     this.initializeLinks()
@@ -61,7 +61,7 @@ class DataHandler {
 
   private addNode(attrs: {}): TNode {
     extend.convert({ immutable: false })(attrs, { size: 0 })
-    return new Node(attrs, this.state.current.get("accessors").node)
+    return new Node(attrs, this.state.current.getAccessors().node)
   }
 
   private calculateNodeSizes(): void {
@@ -100,7 +100,7 @@ class DataHandler {
   }
 
   private addLink(attrs: LinkAttrs): TLink {
-    return new Link(attrs, this.state.current.get("accessors").link)
+    return new Link(attrs, this.state.current.getAccessors().link)
   }
 
   private computeLinks(): void {
@@ -136,7 +136,7 @@ class DataHandler {
   }
 
   private xGridSpacing(): number {
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     const finiteWidth = isFinite(config.width)
     const xValues = map(get("x"))(this.layout.nodes)
     const maxX = xValues.length > 0 ? Math.max(...xValues) : 0
@@ -150,7 +150,7 @@ class DataHandler {
   }
 
   private yGridSpacing(nRows: number): number {
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     const finiteHeight = isFinite(config.height)
     const spacing = isFinite(config.height)
       ? Math.min(config.height / (nRows + 1), config.verticalNodeSpacing)

--- a/src/ProcessFlow/facade.ts
+++ b/src/ProcessFlow/facade.ts
@@ -11,6 +11,7 @@ import {
   Accessors,
   AccessorsObject,
   Components,
+  Computed,
   Facade,
   FocusElement,
   InputData,
@@ -84,7 +85,7 @@ class ProcessFlowFacade implements Facade {
   private context: Element
   private events: EventEmitter
   private series: Series
-  private state: StateHandler<ProcessFlowConfig, InputData>
+  private state: StateHandler<InputData, ProcessFlowConfig, AccessorsObject, Computed>
 
   constructor(context: Element) {
     this.context = context
@@ -99,7 +100,7 @@ class ProcessFlowFacade implements Facade {
     return new EventEmitter()
   }
 
-  private initializeState(): StateHandler<ProcessFlowConfig, InputData> {
+  private initializeState(): StateHandler<InputData, ProcessFlowConfig, AccessorsObject, Computed> {
     return new StateHandler({
       data: {},
       config: defaultConfig(),

--- a/src/ProcessFlow/focus.ts
+++ b/src/ProcessFlow/focus.ts
@@ -45,7 +45,7 @@ class ProcessFlowFocus implements Focus {
     const focusPoint = payload.focusPoint
     const datum = payload.d
     const isNode = focusPoint.type === "node"
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
 
     if (isNode ? !config.showNodeFocusLabels : !config.showLinkFocusLabels) {
       return
@@ -61,7 +61,7 @@ class ProcessFlowFocus implements Focus {
       .attr("class", styles.title)
       .text(datum.label())
       .append("span")
-      .text(` (${this.state.current.get("config").numberFormatter(datum.size())})`)
+      .text(` (${this.state.current.getConfig().numberFormatter(datum.size())})`)
 
     // @TODO remove? Doesn't seem to be doing anything...
     if (datum.content().length > 0) {
@@ -77,7 +77,7 @@ class ProcessFlowFocus implements Focus {
     const labelDims = labelDimensions(this.el)
     const drawingDimensions = this.getDrawingDimensions()
     const offset = focusPoint.offset + config.nodeBorderWidth
-    const labelPosition = this.state.current.get("config").focusLabelPosition
+    const labelPosition = this.state.current.getConfig().focusLabelPosition
 
     positionLabel(this.el, focusPoint, labelDims, drawingDimensions, offset, labelPosition)
   }
@@ -105,7 +105,7 @@ class ProcessFlowFocus implements Focus {
       endsHerePercentage: number = Math.round((datum.journeyEnds * 100) / inputsTotal),
       startsHereString: string = !isNaN(startsHerePercentage) ? `${startsHerePercentage}% of all outputs` : " ",
       endsHereString: string = !isNaN(endsHerePercentage) ? `${endsHerePercentage}% of all inputs` : " ",
-      numberFormatter: (x: number) => string = this.state.current.get("config").numberFormatter
+      numberFormatter: (x: number) => string = this.state.current.getConfig().numberFormatter
 
     // Add "Starts here" breakdown
     flow(
@@ -149,8 +149,8 @@ class ProcessFlowFocus implements Focus {
   }
 
   private getDrawingDimensions(): { xMax: number; xMin: number; yMax: number; yMin: number } {
-    const drawingContainer = this.state.current.get("computed").canvas.elRect
-    const computedSeries = this.state.current.get("computed").series
+    const drawingContainer = this.state.current.getComputed().canvas.elRect
+    const computedSeries = this.state.current.getComputed().series
 
     return {
       xMax: drawingContainer.left + computedSeries.width,

--- a/src/ProcessFlow/renderers/links.ts
+++ b/src/ProcessFlow/renderers/links.ts
@@ -3,7 +3,7 @@ import "d3-transition"
 import { easeCubicInOut } from "d3-ease"
 import { withD3Element } from "../../utils/d3_utils"
 import * as styles from "./styles"
-import { every, find, invoke, map } from "lodash/fp"
+import { find } from "lodash/fp"
 import Events from "../../shared/event_catalog"
 import { exitGroups, filterByMatchers, sizeScale } from "./renderer_utils"
 
@@ -122,7 +122,7 @@ class Links implements Renderer {
 
   draw(data: TLink[]): void {
     this.data = data
-    this.config = this.state.current.get("config")
+    this.config = this.state.current.getConfig()
     const groups = this.el
       .select("g.links-group")
       .selectAll("g.link-group")
@@ -188,7 +188,7 @@ class Links implements Renderer {
   // Paths start as a single point at the source node. If the source node has already been rendered,
   // use its position at the start of the transition.
   private startPath(link: TLink): string {
-    const previousData = this.state.previous.get(["computed", "series", "data"])
+    const previousData = this.state.previous.getComputed().series.data
     const previousNodes = previousData ? previousData.nodes : []
     const existingSource = find((node: TNode) => node.id() === link.sourceId())(previousNodes)
     const x = existingSource ? existingSource.x : link.source().x

--- a/src/ProcessFlow/renderers/nodes.ts
+++ b/src/ProcessFlow/renderers/nodes.ts
@@ -4,7 +4,6 @@ import { symbol as d3Symbol, symbolDiamond, symbolSquare, symbolCircle } from "d
 import { withD3Element, onTransitionEnd } from "../../utils/d3_utils"
 import * as styles from "./styles"
 import Events from "../../shared/event_catalog"
-import { every, invoke, map } from "lodash/fp"
 import { exitGroups, filterByMatchers, sizeScale } from "./renderer_utils"
 
 import {
@@ -141,7 +140,7 @@ class Nodes implements Renderer {
 
   draw(data: TNode[]): void {
     this.data = data
-    this.config = this.state.current.get("config")
+    this.config = this.state.current.getConfig()
     const groups = this.el
       .select("g.nodes-group")
       .selectAll("g.node-group")
@@ -264,7 +263,7 @@ class Nodes implements Renderer {
   }
 
   private getAutomaticLabelPosition(d: TNode): string {
-    const columnSpacing = this.state.current.get("computed").series.horizontalNodeSpacing
+    const columnSpacing = this.state.current.getComputed().series.horizontalNodeSpacing
     return (d.x / columnSpacing) % 2 === 1 ? "top" : "bottom"
   }
 
@@ -280,7 +279,7 @@ class Nodes implements Renderer {
 
   private getLabelText(d: TNode): string {
     // Pixel width of character approx 1/2 of font-size - allow 7px per character
-    const desiredPixelWidth = this.state.current.get("computed").series.horizontalNodeSpacing
+    const desiredPixelWidth = this.state.current.getComputed().series.horizontalNodeSpacing
     const numberOfCharacters = desiredPixelWidth / 7
     return d.label().substring(0, numberOfCharacters) + (d.label().length > numberOfCharacters ? "..." : "")
   }

--- a/src/ProcessFlow/series.ts
+++ b/src/ProcessFlow/series.ts
@@ -28,7 +28,7 @@ class Series {
   }
 
   draw(): void {
-    const seriesConfig = this.state.current.get("computed").series
+    const seriesConfig = this.state.current.getComputed().series
     this.el.attr("width", seriesConfig.width).attr("height", seriesConfig.height)
     this.renderer.draw(this.data)
     this.drawn = true

--- a/src/ProcessFlow/typings.ts
+++ b/src/ProcessFlow/typings.ts
@@ -3,7 +3,7 @@ import * as d3 from "d3-selection"
 import Nodes from "./node"
 import Link from "./link"
 
-import { Accessor, Config, D3Selection, Focus, Facade } from "../shared/typings"
+import { Accessor, BaseConfig, D3Selection, Focus, Facade, ChartStateReadOnly } from "../shared/typings"
 
 export {
   Accessor,
@@ -13,11 +13,12 @@ export {
   Dimensions,
   EventBus,
   Position,
-  State,
   StateWriter,
 } from "../shared/typings"
 
-export interface ProcessFlowConfig extends Config {
+export type State = ChartStateReadOnly<InputData, ProcessFlowConfig, AccessorsObject, Computed>
+
+export interface ProcessFlowConfig extends BaseConfig {
   borderColor: string
   focusElement?: FocusElement
   focusLabelPosition: string
@@ -117,9 +118,9 @@ export interface InputData {
 }
 
 export interface Computed {
-  canvas: { [key: string]: any }
-  focus: { [key: string]: any }
-  series: { [key: string]: any }
+  canvas?: { [key: string]: any }
+  focus?: { [key: string]: any }
+  series?: { [key: string]: any }
 }
 
 export interface Data {

--- a/src/Sunburst/breadcrumb.ts
+++ b/src/Sunburst/breadcrumb.ts
@@ -1,6 +1,6 @@
-import { ClickPayload, D3Selection, Datum, EventBus, HoverPayload, State, StateWriter, SunburstConfig } from "./typings"
+import { ClickPayload, D3Selection, Datum, EventBus, HoverPayload, State, StateWriter } from "./typings"
 import Events from "../shared/event_catalog"
-import { clone, defaults, isEmpty, isObject, last } from "lodash/fp"
+import { clone, defaults } from "lodash/fp"
 import * as styles from "./styles"
 import { readableTextColor } from "../utils/color"
 
@@ -25,13 +25,13 @@ class Breadcrumb {
 
   private updateHoverPath(payload: HoverPayload | ClickPayload): void {
     // Only display breadcrumb if drawing area is wide enough.
-    const config: SunburstConfig = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     const maxBreadcrumbWidth: number = config.breadcrumbItemWidth * config.maxBreadcrumbLength + ARROW_WIDTH
-    if (this.state.current.get("config").width < maxBreadcrumbWidth) {
+    if (this.state.current.getConfig().width < maxBreadcrumbWidth) {
       return
     }
 
-    const computed = this.state.current.get("computed").renderer
+    const computed = this.state.current.getComputed().renderer
     const fixedNode = computed.zoomNode || computed.topNode
     if (!fixedNode || (payload.d && payload.d.data.empty)) {
       return
@@ -45,7 +45,7 @@ class Breadcrumb {
   }
 
   private truncateNodeArray(nodeArray: Datum[]): (Datum | string)[] {
-    const maxLength: number = this.state.current.get("config").maxBreadcrumbLength
+    const maxLength: number = this.state.current.getConfig().maxBreadcrumbLength
     if (nodeArray.length <= maxLength) {
       return nodeArray
     }
@@ -73,7 +73,7 @@ class Breadcrumb {
     trail.exit().remove()
 
     // Add breadcrumb and label for entering nodes.
-    const itemWidth = (d: Datum): number => (d.hops ? HOPS_WIDTH : this.state.current.get("config").breadcrumbItemWidth)
+    const itemWidth = (d: Datum): number => (d.hops ? HOPS_WIDTH : this.state.current.getConfig().breadcrumbItemWidth)
 
     const entering: D3Selection = trail
       .enter()

--- a/src/Sunburst/canvas.ts
+++ b/src/Sunburst/canvas.ts
@@ -91,7 +91,7 @@ class SunburstCanvas implements Canvas {
   }
 
   private drawingDims(): Dimensions {
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     return {
       width: config.width,
       height: config.height - this.breadcrumb.node().getBoundingClientRect().height,
@@ -100,12 +100,12 @@ class SunburstCanvas implements Canvas {
 
   // Lifecycle
   draw(): void {
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     const drawingDims = this.drawingDims()
     this.stateWriter("drawingDims", drawingDims)
 
     this.chartContainer
-      .style("visibility", this.state.current.get("config").hidden ? "hidden" : "visible")
+      .style("visibility", this.state.current.getConfig().hidden ? "hidden" : "visible")
       .style("width", config.width + "px")
       .style("height", config.height + "px")
     this.el.style("width", drawingDims.width + "px").style("height", drawingDims.height + "px")

--- a/src/Sunburst/facade.ts
+++ b/src/Sunburst/facade.ts
@@ -9,7 +9,7 @@ import { has, uniqueId } from "lodash/fp"
 import { colorAssigner } from "../utils/colorAssigner"
 import theme from "../utils/constants"
 import defaultNumberFormatter from "../utils/number_formatter"
-import { Accessors, AccessorsObject, Components, Facade, RawData, SunburstConfig } from "./typings"
+import { Accessors, AccessorsObject, Components, Computed, Facade, RawData, SunburstConfig } from "./typings"
 
 const defaultConfig = (): SunburstConfig => {
   return {
@@ -62,7 +62,7 @@ class SunburstFacade implements Facade {
   private context: Element
   private customColorAccessor: boolean = false
   private events: EventEmitter
-  private state: StateHandler<SunburstConfig, RawData>
+  private state: StateHandler<RawData, SunburstConfig, AccessorsObject, Computed>
 
   constructor(context: Element) {
     this.context = context
@@ -76,7 +76,7 @@ class SunburstFacade implements Facade {
     return new EventEmitter()
   }
 
-  private initializeState(): StateHandler<SunburstConfig, RawData> {
+  private initializeState(): StateHandler<RawData, SunburstConfig, AccessorsObject, Computed> {
     return new StateHandler({
       data: {},
       config: defaultConfig(),

--- a/src/Sunburst/focus.ts
+++ b/src/Sunburst/focus.ts
@@ -29,7 +29,7 @@ class SunburstFocus implements Focus {
       return
     }
 
-    const computed = this.state.current.get("computed")
+    const computed = this.state.current.getComputed()
     const datum = payload.d
     const focusPoint = payload.focusPoint
 
@@ -46,7 +46,7 @@ class SunburstFocus implements Focus {
       .attr("class", "title")
       .text(dataName(datum))
 
-    content.append("span").text(`(${this.state.current.get("config").numberFormatter(dataValue(datum))})`)
+    content.append("span").text(`(${this.state.current.getConfig().numberFormatter(dataValue(datum))})`)
 
     const comparisonNode: Datum = computed.renderer.zoomNode || computed.renderer.topNode
     const percentage: string = ((dataValue(datum) * 100) / dataValue(comparisonNode)).toPrecision(3)
@@ -54,10 +54,10 @@ class SunburstFocus implements Focus {
 
     const focus = { x: focusPoint.centroid[0], y: focusPoint.centroid[1] }
     const labelDims = labelDimensions(this.el)
-    const drawingDims = this.state.current.get("computed").canvas.drawingDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingDims
     const drawingDimensions = {
       xMin: 0,
-      yMin: this.state.current.get("config").height - drawingDims.height,
+      yMin: this.state.current.getConfig().height - drawingDims.height,
       xMax: drawingDims.width,
       yMax: drawingDims.height,
     }
@@ -67,13 +67,13 @@ class SunburstFocus implements Focus {
       focus,
       labelDims,
       drawingDimensions,
-      this.state.current.get("config").focusOffset,
+      this.state.current.getConfig().focusOffset,
       focusPoint.labelPosition,
     )
   }
 
   private percentageString(datum: Datum): string {
-    const computed = this.state.current.get("computed")
+    const computed = this.state.current.getComputed()
     const topNode = computed.renderer.topNode
     const zoomNode = computed.renderer.zoomNode
     return !zoomNode || topNode === zoomNode
@@ -82,7 +82,7 @@ class SunburstFocus implements Focus {
   }
 
   private singlePercentageString(datum: Datum, comparison: Datum): string {
-    const topNode: Datum = this.state.current.get("computed").renderer.topNode
+    const topNode: Datum = this.state.current.getComputed().renderer.topNode
     const percentage: string = ((dataValue(datum) * 100) / dataValue(comparison)).toPrecision(3)
     return `${percentage}% of ${dataName(comparison)}`
   }

--- a/src/Sunburst/renderer.ts
+++ b/src/Sunburst/renderer.ts
@@ -53,7 +53,7 @@ class Renderer {
       .selectAll(`path.${styles.arc}`)
       .data(this.data, get("id"))
 
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
     this.exit(arcs, config.duration, document.hidden || config.disableAnimations)
     this.enterAndUpdate(arcs, config.duration, document.hidden || config.disableAnimations)
   }
@@ -75,7 +75,7 @@ class Renderer {
   }
 
   private updateZoom(): void {
-    const matchers = this.state.current.get("config").zoomNode
+    const matchers = this.state.current.getConfig().zoomNode
     const zoomNode: Datum = find(
       (d: Datum): boolean => {
         return every(identity)(
@@ -124,9 +124,9 @@ class Renderer {
 
   // Computations
   private compute(): void {
-    const drawingDims = this.state.current.get("computed").canvas.drawingDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingDims
     this.radius =
-      Math.min(drawingDims.width, drawingDims.height) / 2 - this.state.current.get("config").outerBorderMargin
+      Math.min(drawingDims.width, drawingDims.height) / 2 - this.state.current.getConfig().outerBorderMargin
 
     this.angleScale = d3ScaleLinear()
       .clamp(true)
@@ -173,7 +173,7 @@ class Renderer {
 
   // Center elements within drawing container
   private translate(): string {
-    const drawingDims = this.state.current.get("computed").canvas.drawingDims
+    const drawingDims = this.state.current.getComputed().canvas.drawingDims
     this.currentTranslation = [drawingDims.width / 2, drawingDims.height / 2]
     return `translate(${this.currentTranslation.join(", ")})`
   }
@@ -298,13 +298,13 @@ class Renderer {
     }
 
     // Set new scale domains
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
 
     let maxChildRadius: number = 0
     let truncated: boolean = false
     forEach(
       (child: Datum): void => {
-        if (child.depth - zoomNode.depth <= this.state.current.get("config").maxRings) {
+        if (child.depth - zoomNode.depth <= this.state.current.getConfig().maxRings) {
           maxChildRadius = Math.max(maxChildRadius, child.y1)
         } else {
           truncated = true
@@ -476,13 +476,13 @@ class Renderer {
   private arrowTransformation(d: Datum): string {
     const radAngle: number = d3Interpolate(this.angleScale(d.x0), this.angleScale(d.x1))(0.5)
     const degAngle: number = (radAngle * 180) / Math.PI
-    const r: number = this.radiusScale(d.y1) + this.state.current.get("config").arrowOffset
+    const r: number = this.radiusScale(d.y1) + this.state.current.getConfig().arrowOffset
     return `translate(0, ${-r}) rotate(${degAngle} 0 ${r})`
   }
 
   private updateTruncationArrows(): void {
     const centerNode = this.zoomNode || this.dataHandler.topNode
-    const config = this.state.current.get("config")
+    const config = this.state.current.getConfig()
 
     const data: Datum[] = map(get("parent"))(
       filter(

--- a/src/Sunburst/root_label.ts
+++ b/src/Sunburst/root_label.ts
@@ -17,8 +17,8 @@ class RootLabel {
   }
 
   private update(): void {
-    const computed = this.state.current.get("computed")
-    const config = this.state.current.get("config")
+    const computed = this.state.current.getComputed()
+    const config = this.state.current.getConfig()
     const renderer = computed.renderer
     const drawingDims = computed.canvas.drawingDims
     const fixedNode = renderer.zoomNode || renderer.topNode

--- a/src/Sunburst/typings.ts
+++ b/src/Sunburst/typings.ts
@@ -3,7 +3,7 @@ import Breadcrumb from "./breadcrumb"
 import Renderer from "./renderer"
 import RootLabel from "./root_label"
 import { HierarchyRectangularNode } from "d3-hierarchy"
-import { Accessor, Config, Focus, Facade } from "../shared/typings"
+import { Accessor, BaseConfig, Focus, Facade, ChartStateReadOnly } from "../shared/typings"
 
 export {
   Accessor,
@@ -14,11 +14,12 @@ export {
   EventBus,
   Point,
   Position,
-  State,
   StateWriter,
 } from "../shared/typings"
 
-export interface SunburstConfig extends Config {
+export type State = ChartStateReadOnly<RawData, SunburstConfig, AccessorsObject, Computed>
+
+export interface SunburstConfig extends BaseConfig {
   arrowOffset: number
   breadcrumbItemWidth: number
   centerCircleRadius: number
@@ -72,9 +73,9 @@ export interface AccessorsObject {
 }
 
 export interface Computed {
-  canvas: { [key: string]: any }
-  focus: { [key: string]: any }
-  renderer: { [key: string]: any }
+  canvas?: { [key: string]: any }
+  focus?: { [key: string]: any }
+  renderer?: { [key: string]: any }
 }
 
 export interface FocusPoint {

--- a/src/shared/component_focus.ts
+++ b/src/shared/component_focus.ts
@@ -1,13 +1,13 @@
-import { ComponentHoverPayload, Config, D3Selection, EventBus, State, ComponentConfigInfo } from "./typings"
+import { ComponentHoverPayload, BaseConfig, D3Selection, EventBus, ChartStateReadOnly, ComponentConfigInfo } from "./typings"
 import Events from "./event_catalog"
 import * as styles from "./styles"
 
 class ComponentFocus {
   el: D3Selection
   events: EventBus
-  state: State
+  state: ChartStateReadOnly<any, any, any, any> // @TODO
 
-  constructor(state: State, el: D3Selection, events: EventBus) {
+  constructor(state: ChartStateReadOnly<any, any, any, any>, el: D3Selection, events: EventBus) {
     this.state = state
     this.el = el.append("xhtml:div").attr("class", `${styles.focusLegend} ${styles.componentFocus}`)
     this.events = events
@@ -15,7 +15,7 @@ class ComponentFocus {
   }
 
   onComponentHover(payload: ComponentHoverPayload): void {
-    if (!this.state.current.get("config").showComponentFocus) {
+    if (!this.state.current.getConfig().showComponentFocus) {
       return
     }
     this.events.emit(Events.FOCUS.CLEAR)
@@ -25,11 +25,11 @@ class ComponentFocus {
 
   draw(payload: ComponentHoverPayload): void {
     const componentPosition: ClientRect = payload.component.node().getBoundingClientRect()
-    const canvasPosition: ClientRect = this.state.current.get("computed").canvas.containerRect
+    const canvasPosition: ClientRect = this.state.current.getComputed().canvas.containerRect
     const elStyle: { [key: string]: any } = window.getComputedStyle(this.el.node())
     const topBorderWidth: number = parseInt(elStyle["border-top-width"], 10)
     const leftBorderWidth: number = parseInt(elStyle["border-left-width"], 10)
-    const config: Config = this.state.current.get("config")
+    const config = this.state.current.getConfig() as Readonly<BaseConfig>
 
     // Prevent component focus from going out of canvas.
     let top: number = componentPosition.top - canvasPosition.top - topBorderWidth

--- a/src/shared/state_handler.ts
+++ b/src/shared/state_handler.ts
@@ -1,32 +1,32 @@
 import State, { ReadOnlyState, Path } from "./state"
 import { Accessor, Accessors, ChartStateObject } from "./typings"
-import { forEach, isEmpty, reduce } from "lodash/fp"
+import { forEach, get, isEmpty, reduce } from "lodash/fp"
 
-export interface ChartState<T> {
-  current: State<T>
-  previous: State<T>
+export interface ChartState<Data, Config, AccessorsObject, Computed> {
+  current: State<Data, Config, AccessorsObject, Computed>
+  previous: State<Data, Config, AccessorsObject, Computed>
 }
 
-export interface ChartStateReadOnly<T> {
-  current: ReadOnlyState<T>
-  previous: ReadOnlyState<T>
+export interface ChartStateReadOnly<Data, Config, AccessorsObject, Computed> {
+  current: ReadOnlyState<Data, Config, AccessorsObject, Computed>
+  previous: ReadOnlyState<Data, Config, AccessorsObject, Computed>
 }
 
 export type StateWriter = (propertyPath: string | string[], value: any) => void
 
-export default class StateHandler<Config, Data> {
-  state: ChartState<ChartStateObject>
+export default class StateHandler<Data, Config, AccessorsObject, Computed> {
+  state: ChartState<Data, Config, AccessorsObject, Computed>
 
-  constructor(obj: ChartStateObject) {
-    const initial = new State<ChartStateObject>(obj)
+  constructor(obj: ChartStateObject<Data, Config, AccessorsObject, Computed>) {
+    const initial = new State<Data, Config, AccessorsObject, Computed>(obj)
     this.state = { current: initial, previous: initial.clone() }
   }
 
   captureState() {
-    this.state.previous.set(["computed"], this.state.current.clone().get("computed"))
+    this.state.previous.set("computed", this.state.current.getComputed())
   }
 
-  readOnly(): ChartStateReadOnly<ChartStateObject> {
+  readOnly() {
     return {
       current: this.state.current.readOnly(),
       previous: this.state.previous.readOnly(),
@@ -35,7 +35,7 @@ export default class StateHandler<Config, Data> {
 
   // Data
   data(data?: Data) {
-    if (!arguments.length) return this.state.current.get("data")
+    if (!arguments.length) return this.state.current.getData()
     return this.state.current.set("data", data)
   }
 
@@ -45,7 +45,7 @@ export default class StateHandler<Config, Data> {
 
   // Config
   config(config?: Partial<Config>) {
-    if (!arguments.length) return this.state.current.get("config")
+    if (!arguments.length) return this.state.current.getConfig()
 
     const invalidOptions: string[] = reduce.convert({ cap: false })(
       (memo: string[], value: any, key: string): string[] => {
@@ -67,7 +67,7 @@ export default class StateHandler<Config, Data> {
 
   // Accessors
   accessors(type: string, accessors?: Accessors<any>) {
-    if (!accessors) return this.state.current.get(["accessors", type])
+    if (!accessors) return get("type")(this.state.current.getAccessors())
     const accessorFuncs: Accessors<any> = reduce.convert({ cap: false })(
       (memo: Accessors<any>, accessor: Accessor<any, any>, key: string) => {
         memo[key] = typeof accessor === "function" ? accessor : () => accessor

--- a/src/shared/typings.ts
+++ b/src/shared/typings.ts
@@ -16,21 +16,17 @@ export interface Accessors<D> {
 }
 
 // State
-import StateHandler, { ChartStateReadOnly } from "./state_handler"
+export { ChartStateReadOnly, StateWriter } from "./state_handler"
 
-export { StateWriter } from "./state_handler"
-
-export type State = ChartStateReadOnly<ChartStateObject>
-
-export interface ChartStateObject {
-  data: any
+export interface ChartStateObject<Data, Config, AccessorsObject, Computed> {
+  data: Data
   config: Config
-  accessors: any
-  computed: { [key: string]: any }
+  accessors: AccessorsObject
+  computed: Computed
 }
 
 // Base config, required for all visualisations
-export interface Config {
+export interface BaseConfig {
   duration: number
   height: number
   hidden: boolean


### PR DESCRIPTION
## Issue
#9 

## Trello
<blockquote class="trello-card"><a href="https://trello.com/c/5dVVYRfg/354-fix-operational-visualizations-install-script">Fix operational-visualizations install script</a></blockquote>

## Summary
Although the original intention was simply to remove the errors thrown when `yarn install` was run, these were symptomatic of deeper issues with the visualization state management. The main issue is that TypeScript's `Readonly<T>` type only makes first-level properties of the provided type readonly, allowing more deeply nested properties to be modified. Deep cloning solves this problem, but then requires repeated deep cloning of the entire state.  

Now, instead of using a generic `get` method to access values saved to the state (e.g. `this.state.current.get("computed").series`, there are 4 distinct get methods: `getData`, `getAccessors`, `getConfig` and `getComputed`. The first 3 of these return Readonly objects, while only the last returns a deep cloned Readonly object. 

Most of the changes in this PR are just changes to the method names. The main files that need review are `src/shared/state.ts`, `src/shared/state_handler.ts`, and the various `typings.ts` files.