### PR TITLE
Add tsconfig to use commonjs instead of esm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ build
 lib
 # Files managed by operational-scripts
 tslint.json
-tsconfig.json
 .prettierrc

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "exclude": ["node_modules", "dist", "lib", "__tests__", "**/*.test*", "**/*.spec*"],
+  "include": ["src"],
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "target": "es5",
+    "module": "commonjs",
+    "lib": ["es2015", "dom", "es2016.array.include", "es2017.object"],
+    "jsx": "react",
+    "declaration": true,
+    "declarationMap": true,
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "downlevelIteration": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "inlineSourceMap": true
+  }
+}


### PR DESCRIPTION
cc @TejasQ, because

```json
    "skipLibCheck": true,
    "target": "es5",
    "module": "esnext",
```

https://github.com/contiamo/operational-scripts/blob/a53652aedae2825d495a3744bdbcdb6fe41878bb/tsconfig.json#L5-L7