### PR TITLE
Use new viz instance when component updates

### DIFF
--- a/src/utils/VisualizationWrapper.tsx
+++ b/src/utils/VisualizationWrapper.tsx
@@ -35,6 +35,8 @@ class VisualizationWrapper extends React.Component<Props, {}> {
   }
 
   public componentDidUpdate() {
+    this.viz.close();
+    this.viz = new this.props.facade(this.containerNode);
     this.updateViz();
     this.viz.draw();
   }


### PR DESCRIPTION
Without this change I got an error when switch between different visualisations of Grid:

```
axes_manager.js:82 Uncaught Error: The following axes have not been configured: x2
    at AxesManager.../../node_modules/@operational/visualizations/lib/Chart/axes_manager.js.AxesManager.updateAxes (axes_manager.js:82)
    at AxesManager.../../node_modules/@operational/visualizations/lib/Chart/axes_manager.js.AxesManager.draw (axes_manager.js:63)
    at ChartFacade.../../node_modules/@operational/visualizations/lib/Chart/facade.js.ChartFacade.draw (facade.js:187)
    at VisualizationWrapper.../../node_modules/@operational/visualizations/lib/utils/VisualizationWrapper.js.VisualizationWrapper.componentDidUpdate (VisualizationWrapper.js:46)
    at commitLifeCycles (react-dom.development.js:17143)
    at commitAllLifeCycles (react-dom.development.js:18530)
    at HTMLUnknownElement.callCallback (react-dom.development.js:149)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:199)
    at invokeGuardedCallback (react-dom.development.js:256)
    at commitRoot (react-dom.development.js:18742)
```

But I suspect (but no proof) that this change can have some negative consequences.

The problem is that `viz` instance has internal state, which is preserved across React component renders, which causes bugs

Published to canary as `@operational/visualizations@6.1.0-349d69e`