### PR TITLE
Fix bug with row headers

### DIFF
--- a/src/NewGrid/coordinateUtils.ts
+++ b/src/NewGrid/coordinateUtils.ts
@@ -403,7 +403,7 @@ export const getRowHeadersCount = <Name extends string = string>({
   measuresPlacement: "row" | "column";
   measuresCount: number;
 }) => {
-  const rowsDepth = data.getPivotRows.length;
+  const rowsDepth = data.getPivotRows().length;
   const showMeasureLabelsInRows = measuresPlacement === "row";
 
   let rowHeadersCount =


### PR DESCRIPTION
In this PR I fix the bug with row headers. It is an epic bug. In JS `function.length` returns number of arguments that function expects, but I wanted to get the length of array returned by the function, so when I didn't use call invocation TS didn't complain.

In this essay I want...