### PR TITLE
Fix PivotFrame row and column indexing.

### DIFF
--- a/packages/frame/src/PivotFrame.ts
+++ b/packages/frame/src/PivotFrame.ts
@@ -55,7 +55,7 @@ export class PivotFrame<Name extends string = string> {
   public row(rowIdentifier: number) {
     this.buildIndex();
     const row = this.rowIndex[rowIdentifier];
-    if (row === undefined) {
+    if (this.rowIndex.length && row === undefined) {
       throw new Error(`Can't find row #${rowIdentifier}`);
     }
     if (!this.rowCache.has(rowIdentifier)) {
@@ -67,7 +67,7 @@ export class PivotFrame<Name extends string = string> {
   public column(columnIdentifier: number) {
     this.buildIndex();
     const column = this.columnIndex[columnIdentifier];
-    if (column === undefined) {
+    if (this.columnIndex.length && column === undefined) {
       throw new Error(`Can't find column #${columnIdentifier}`);
     }
     if (!this.columnCache.has(columnIdentifier)) {

--- a/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
@@ -274,6 +274,7 @@ storiesOf("@operational/grid/1. Pivot table", module)
       columns: [],
     });
 
+    console.log(pivotedFrame.row(0));
     return (
       <AutoSizer style={{ minHeight: "500px", height: "100%" }}>
         {({ width, height }) => (


### PR DESCRIPTION
After allowing zero rows and columns, the `row` and `column` methods on `PivotFrame` were broken, returning `Can't find row/column #0`.