### PR TITLE
Fix pivoting in one direction case

### DIFF
--- a/packages/frame/src/PivotFrame.ts
+++ b/packages/frame/src/PivotFrame.ts
@@ -44,19 +44,21 @@ export class PivotFrame<Name extends string = string> {
   }
 
   public rowHeaders() {
+    if (this.prop.rows.length === 0) return [];
+
     this.buildIndex();
     return this.rowHeadersInternal;
   }
 
   public columnHeaders() {
+    if (this.prop.columns.length === 0) return [];
+
     this.buildIndex();
     return this.columnHeadersInternal;
   }
 
   public row(rowIdentifier: number) {
-    if (this.prop.rows.length === 0) {
-      return this.getFrameWithoutPivoting();
-    }
+    if (this.prop.rows.length === 0) return this.getFrameWithoutPivoting();
 
     this.buildIndex();
     const row = this.rowIndex[rowIdentifier];
@@ -70,9 +72,7 @@ export class PivotFrame<Name extends string = string> {
   }
 
   public column(columnIdentifier: number) {
-    if (this.prop.columns.length === 0) {
-      return this.getFrameWithoutPivoting();
-    }
+    if (this.prop.columns.length === 0) return this.getFrameWithoutPivoting();
 
     this.buildIndex();
     const column = this.columnIndex[columnIdentifier];
@@ -86,9 +86,7 @@ export class PivotFrame<Name extends string = string> {
   }
 
   public cell(rowIdentifier: number, columnIdentifier: number) {
-    if (this.prop.rows.length === 0 && this.prop.columns.length === 0) {
-      return this.getFrameWithoutPivoting();
-    }
+    if (this.prop.rows.length === 0 && this.prop.columns.length === 0) return this.getFrameWithoutPivoting();
 
     this.buildIndex();
     if (this.prop.rows.length === 0) {

--- a/packages/grid/src/coordinateUtils.ts
+++ b/packages/grid/src/coordinateUtils.ts
@@ -473,8 +473,8 @@ export const getColumnCount = <Name extends string = string>({
   measuresCount: number;
   rowHeadersCount: number;
 }) => {
-  if (data.columnHeaders().length === 0 && data.rowHeaders().length === 0) {
-    return measuresPlacement === "column" ? measuresCount : 2;
+  if (data.columnHeaders().length === 0) {
+    return rowHeadersCount + (measuresPlacement === "column" ? measuresCount : 2);
   } else {
     return rowHeadersCount + data.columnHeaders().length * (measuresPlacement === "column" ? measuresCount : 1);
   }
@@ -495,8 +495,8 @@ export const getRowCount = <Name extends string = string>({
   measuresCount: number;
   columnHeadersCount: number;
 }) => {
-  if (data.columnHeaders().length === 0 && data.rowHeaders().length === 0) {
-    return measuresPlacement === "row" ? measuresCount : 2;
+  if (data.rowHeaders().length === 0) {
+    return columnHeadersCount + (measuresPlacement === "row" ? measuresCount : 2);
   } else {
     return columnHeadersCount + data.rowHeaders().length * (measuresPlacement === "row" ? measuresCount : 1);
   }

--- a/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
@@ -216,6 +216,7 @@ storiesOf("@operational/grid/1. Pivot table", module)
             style={{
               cell: { padding: "10px", textAlign: "right" },
             }}
+            cell={({ measure }: { measure: string }) => `${measure}`}
           />
         )}
       </AutoSizer>


### PR DESCRIPTION
**Before**:

<img width="803" alt="Screenshot 2019-07-09 at 11 14 31" src="https://user-images.githubusercontent.com/179534/60875779-d9f49b00-a23a-11e9-9bd0-8c1695806290.png">

**After**:

<img width="813" alt="Screenshot 2019-07-09 at 11 15 18" src="https://user-images.githubusercontent.com/179534/60875788-de20b880-a23a-11e9-822b-3ff3b8dabb6f.png">

**Explanation**: code tried to show table even for the case when DataFrame contained more data than PivotGrid needs, to do this there was special logic which created virtual rows (or columns) even when we didn't ask to pivot along this direction. This code allowed to show "plain" pivotgrid for this case, but it breaks for case when we want to show visualisations in cells