### PR TITLE
Pass measure name to PivotFrame axis method.

### DIFF
--- a/packages/grid/src/PivotGrid.tsx
+++ b/packages/grid/src/PivotGrid.tsx
@@ -104,8 +104,8 @@ interface Accessors<Name extends string> {
 }
 
 interface Axes {
-  row?: (rowProps: { row: number; width: number; height: number }) => React.ReactNode;
-  column?: (columnProps: { column: number; width: number; height: number }) => React.ReactNode;
+  row?: (rowProps: { row: number; measure?: string, width: number; height: number }) => React.ReactNode;
+  column?: (columnProps: { column: number; measure?: string, width: number; height: number }) => React.ReactNode;
 }
 
 interface PivotGridStyle {
@@ -280,12 +280,12 @@ export const PivotGrid = React.memo(<Name extends string = string>(props: Props<
           break;
         case "RowAxis":
           if (axes.row) {
-            item = axes.row({ row: cellCoordinates.row, height, width });
+            item = axes.row({ row: cellCoordinates.row, measure: cellCoordinates.measure, height, width });
           }
           break;
         case "ColumnAxis":
           if (axes.column) {
-            item = axes.column({ column: cellCoordinates.column, height, width });
+            item = axes.column({ column: cellCoordinates.column, measure: cellCoordinates.measure, height, width });
           }
           break;
         default:


### PR DESCRIPTION
For computing quantitative axes, we need to know the name of the measure to ensure that all axes for that measure are the same across all rows/columns. 