### PR TITLE
Add ChartGrid.

### DIFF
--- a/packages/grid/src/ChartGrid.tsx
+++ b/packages/grid/src/ChartGrid.tsx
@@ -1,0 +1,140 @@
+import { DataFrame, FragmentFrame, PivotFrame, uniqueValues } from "@operational/frame";
+import { PivotGrid } from ".";
+import { Axis, useScaleBand, useScaleLinear } from "@operational/visualizations";
+import React, { ReactNode } from "react";
+
+// TODO Move to @operational/grid
+interface ChartGridProps<Name extends string> {
+  width: number;
+  height: number;
+  data: DataFrame<string>;
+  query: { rows: Name[], columns: Name[] };
+  renderer: any;
+  measuresInRow: boolean;
+  measures: Name[];
+}
+
+interface CellProps<Name extends string> {
+  data: FragmentFrame<Name>;
+  width: number;
+  height: number;
+  row: number;
+  column: number;
+  measure: Name;
+}
+
+const tickWidth = 25;
+const defaultCellSize = 200;
+
+const axes = (data: DataFrame<string>, pivotedFrame: PivotFrame<string>, categorical: string) => {
+  return {
+    row: ({row, measure, width, height}: {row: number, measure?: string, width: number, height: number}) => {
+      const scale = !!measure
+        ? useScaleLinear({
+          frame: data,
+          column: measure,
+          range: [height, 0]
+        })
+        : useScaleBand({
+          frame: pivotedFrame.row(row),
+          column: categorical,
+          range: [height, 0]
+        })
+      return <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+        <Axis scale={scale} position="left" transform={`translate(${width}, 0)`}/>
+      </svg>
+    },
+    // TODO Re-implement once tick spacing or another way of displaying labels without overlap has been implemented
+    column: ({column, measure, width, height}: {column: number, measure?: string, width: number, height: number}) => {
+      const scale = !!measure
+        ? useScaleLinear({
+          frame: data,
+          column: measure,
+          range: [0, width],
+        })
+        : useScaleBand({
+          frame: pivotedFrame.column(column),
+          column: categorical,
+          range: [0, width],
+        })
+      return <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+        <Axis scale={scale} position="top" transform={`translate(0, ${height})`}/>
+      </svg>
+    }
+  }
+}
+
+// TODO replace Renderer type once @operational/visualizations has a general interface for chart renderers
+const cell = (dataFrame: DataFrame<string>, categorical: string, measuresInRow: boolean, Renderer: any) => {
+  return ({ data, width, height, measure }: CellProps<string>): ReactNode => {
+    const categoricalScale = useScaleBand({
+      frame: data,
+      column: categorical,
+      range: measuresInRow ? [0, width] : [height, 0]
+    });
+    const metricScale = useScaleLinear({
+      frame: dataFrame,
+      column: measure,
+      range: measuresInRow ? [height, 0] : [0, width]
+    });
+    return (
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+      >
+        <Renderer
+          direction={measuresInRow ? "vertical" : "horizontal"}
+          data={data}
+          metricScale={metricScale}
+          categoricalScale={categoricalScale}
+          metric={dataFrame.getCursor(measure)}
+          categorical={dataFrame.getCursor(categorical)}
+          style={{ fill: "#1f78b4" }}
+        />
+      </svg>
+    );
+  }
+}
+
+export const ChartGrid = ({ width, height, data, query, measuresInRow, measures, renderer: Renderer }: ChartGridProps<string>) => {
+  const rows = query.rows.slice(0, -(measuresInRow ? measures.length : 1))
+  const columns = query.columns.slice(0, -(measuresInRow ? 1 : measures.length))
+  const pivotedFrame = data.pivot({ rows, columns })
+  const categorical = measuresInRow ? query.columns[query.columns.length - 1] : query.rows[query.rows.length - 1];
+
+  return <PivotGrid
+    type="generalWithMeasures"
+    measures={measures}
+    measuresPlacement={measuresInRow ? "row" : "column"}
+    width={width}
+    height={height}
+    data={pivotedFrame}
+    axes={axes(data, pivotedFrame, categorical)}
+    accessors={{
+      height: param => {
+        if (!measuresInRow && "row" in param) {
+          return uniqueValues(pivotedFrame.row(param.row), query.rows[query.rows.length - 1]).length * tickWidth
+        }
+        if ("axis" in param && param.axis === true) {
+          return 30
+        }
+        return "columnIndex" in param || ("measure" in param && param.measure === true)
+          ? 35
+          : defaultCellSize
+      },
+      width: param => {
+        if (measuresInRow && "column" in param) {
+          return uniqueValues(pivotedFrame.column(param.column), query.columns[query.columns.length - 1]).length * tickWidth
+        }
+        if ("axis" in param && param.axis === true) {
+          return measuresInRow ? 50 : 150
+        }
+        return "rowIndex" in param || ("measure" in param && param.measure === true)
+          ? 120
+          : defaultCellSize
+      }
+    }}
+    cell={cell(data, categorical, measuresInRow, Renderer)}
+  />
+};

--- a/packages/grid/src/index.ts
+++ b/packages/grid/src/index.ts
@@ -2,3 +2,4 @@ export * from "./types";
 
 export { PivotGrid } from "./PivotGrid";
 export { TableGrid } from "./TableGrid";
+export { ChartGrid } from "./ChartGrid";

--- a/packages/visualizations-stories/src/grid/3-chart-grid-stories.tsx
+++ b/packages/visualizations-stories/src/grid/3-chart-grid-stories.tsx
@@ -1,0 +1,157 @@
+import { DataFrame } from "@operational/frame";
+import { ChartGrid } from "@operational/grid";
+import { Bars } from "@operational/visualizations";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import AutoSizer from "react-virtualized-auto-sizer";
+
+const rawData = {
+  columns: [
+    {
+      name: "Customer.Continent" as "Customer.Continent",
+      type: "string",
+    },
+    {
+      name: "Customer.Country" as "Customer.Country",
+      type: "string",
+    },
+    {
+      name: "Customer.City" as "Customer.City",
+      type: "string",
+    },
+    {
+      name: "Customer.AgeGroup" as "Customer.AgeGroup",
+      type: "string",
+    },
+    {
+      name: "Customer.Gender" as "Customer.Gender",
+      type: "string",
+    },
+    {
+      name: "sales" as "sales",
+      type: "number",
+    },
+    {
+      name: "revenue" as "revenue",
+      type: "number",
+    },
+  ],
+  rows: [
+    ["Europe", "Germany", "Berlin", "<50", "Female", 101, 10.2],
+    ["Europe", "Germany", "Dresden", "<50", "Female", 201, 20.2],
+    ["Europe", "Germany", "Hamburg", "<50", "Female", 301, 30.2],
+    ["Europe", "UK", "London", "<50", "Female", 401, 40.2],
+    ["Europe", "UK", "Edinburgh", "<50", "Female", 501, 50.2],
+    ["Europe", "UK", "Dresden", "<50", "Female", 701, 70.2],
+    ["North America", "USA", "New York", "<50", "Female", 801, 80.2],
+    ["North America", "Canada", "Toronto", "<50", "Female", 901, 90.2],
+    ["Europe", "Germany", "Berlin", "<50", "Male", 103, 10.4],
+    ["Europe", "Germany", "Dresden", "<50", "Male", 203, 20.4],
+    ["Europe", "Germany", "Hamburg", "<50", "Male", 303, 30.4],
+    ["Europe", "UK", "London", "<50", "Male", 403, 40.4],
+    ["Europe", "UK", "Edinburgh", "<50", "Male", 503, 50.4],
+    ["Europe", "UK", "Dresden", "<50", "Male", 703, 70.4],
+    ["North America", "USA", "New York", "<50", "Male", 803, 80.4],
+    ["North America", "Canada", "Toronto", "<50", "Male", 903, 90.4],
+    ["Europe", "Germany", "Berlin", ">=50", "Female", 105, 10.6],
+    ["Europe", "Germany", "Dresden", ">=50", "Female", 205, 20.6],
+    ["Europe", "Germany", "Hamburg", ">=50", "Female", 305, 30.6],
+    ["Europe", "UK", "London", ">=50", "Female", 405, 40.6],
+    ["Europe", "UK", "Edinburgh", ">=50", "Female", 505, 50.6],
+    ["Europe", "UK", "Dresden", ">=50", "Female", 705, 70.6],
+    ["North America", "USA", "New York", ">=50", "Female", 805, 80.6],
+    ["North America", "Canada", "Toronto", ">=50", "Female", 905, 90.6],
+    ["Europe", "Germany", "Berlin", ">=50", "Male", 107, 10.8],
+    ["Europe", "Germany", "Dresden", ">=50", "Male", 207, 20.8],
+    ["Europe", "Germany", "Hamburg", ">=50", "Male", 307, 30.8],
+    ["Europe", "UK", "London", ">=50", "Male", 407, 40.8],
+    ["Europe", "UK", "Edinburgh", ">=50", "Male", 507, 50.8],
+    ["Europe", "UK", "Dresden", ">=50", "Male", 707, 70.8],
+    ["North America", "USA", "New York", ">=50", "Male", 807, 80.8],
+    ["North America", "Canada", "Toronto", ">=50", "Male", 907, 90.8],
+  ],
+};
+
+const frame = new DataFrame(rawData.columns, rawData.rows);
+
+storiesOf("@operational/grid/3. Chart grid", module)
+  .add("single chart", () => {
+    return (
+      <AutoSizer style={{ minHeight: "500px", height: "100%" }}>
+        {({ width, height }) => (
+          <ChartGrid
+            width={width}
+            height={height}
+            data={frame}
+            query={{
+              rows: ["Customer.Country"],
+              columns: ["sales"]
+            }}
+            renderer={Bars}
+            measuresInRow={false}
+            measures={["sales"]}
+          />
+        )}
+      </AutoSizer>
+    );
+  })
+  .add("multiple measures", () => {
+    return (
+      <AutoSizer style={{ minHeight: "500px", height: "100%" }}>
+        {({ width, height }) => (
+          <ChartGrid
+            width={width}
+            height={height}
+            data={frame}
+            query={{
+              rows: ["Customer.Country"],
+              columns: ["sales", "revenue"]
+            }}
+            renderer={Bars}
+            measuresInRow={false}
+            measures={["sales", "revenue"]}
+          />
+        )}
+      </AutoSizer>
+    );
+  })
+  .add("multiple row dimensions", () => {
+    return (
+      <AutoSizer style={{ minHeight: "500px", height: "100%" }}>
+        {({ width, height }) => (
+          <ChartGrid
+            width={width}
+            height={height}
+            data={frame}
+            query={{
+              rows: ["Customer.Country", "Customer.City"],
+              columns: ["sales", "revenue"]
+            }}
+            renderer={Bars}
+            measuresInRow={false}
+            measures={["sales", "revenue"]}
+          />
+        )}
+      </AutoSizer>
+    );
+  })
+  .add("multiple column dimensions", () => {
+    return (
+      <AutoSizer style={{ minHeight: "500px", height: "100%" }}>
+        {({ width, height }) => (
+          <ChartGrid
+            width={width}
+            height={height}
+            data={frame}
+            query={{
+              rows: ["Customer.Continent", "Customer.Country", "Customer.City"],
+              columns: ["Customer.AgeGroup", "Customer.Gender", "sales", "revenue"]
+            }}
+            renderer={Bars}
+            measuresInRow={false}
+            measures={["sales", "revenue"]}
+          />
+        )}
+      </AutoSizer>
+    );
+  })


### PR DESCRIPTION
Add ChartGrid component for rendering axial charts (currently only bar charts) in grids. If there is only one row and one column, it will render a single chart.

Still to do:

- [ ] Make axes look a bit nicer
- [ ] Smarter sizing
- [ ] Tidy code