### PR TITLE
Fix render prop and hooks issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "tsc --build",
     "build:stories": "lerna run build --stream --scope=@operational/visualizations-stories",
     "clean": "rimraf packages/*/{tsconfig.tsbuildinfo,lib,dist}",
+    "clean_modules": "rm -rf node_modules packages/*/node_modules && yarn",
     "lint": "eslint packages/**/src/**/*.{ts,tsx}"
   },
   "devDependencies": {

--- a/packages/frame/Readme.md
+++ b/packages/frame/Readme.md
@@ -136,5 +136,4 @@ FragmentFrame - limited version of DataFrame. Maybe in the future we will remove
 
 At the moment of writing it exposes:
 
-- `forEach` method to iterate over the rows and
 - `peak` method to select value of column from the first row of frame (assumes there is only one row in the frame). Used for the `<PivotGrid />`

--- a/packages/frame/package.json
+++ b/packages/frame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@operational/frame",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Contiamo DataFrame.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/frame/src/DataFrame.ts
+++ b/packages/frame/src/DataFrame.ts
@@ -42,18 +42,6 @@ export class DataFrame<Name extends string = string> implements IteratableFrame<
     return this.data.map(callback);
   }
 
-  public forEach(columns: Name | Name[], cb: (...columnValue: any[]) => void) {
-    if (!Array.isArray(columns)) {
-      columns = [columns];
-    }
-
-    const columnsIndex = columns.map(column => this.schema.findIndex(x => x.name === column));
-    if (columnsIndex.some(x => x < 0)) {
-      throw new Error(`Unknown column in ${columns}`);
-    }
-    this.data.forEach(dataRow => cb(...columnsIndex.map(columnIndex => dataRow[columnIndex])));
-  }
-
   public pivot<Column extends Name, Row extends Name>(prop: PivotProps<Column, Row>) {
     // check if the input params are valid
     return new PivotFrame(this.schema, this.data, prop);

--- a/packages/frame/src/FragmentFrame.ts
+++ b/packages/frame/src/FragmentFrame.ts
@@ -15,19 +15,6 @@ export class FragmentFrame<Name extends string = string> implements IteratableFr
     return this.index.map((i, j) => callback(this.data[i], j));
   }
 
-  public forEach(columns: Name | Name[], cb: (...columnValue: any[]) => void) {
-    if (!Array.isArray(columns)) {
-      columns = [columns];
-    }
-
-    const columnsIndex = columns.map(column => this.schema.findIndex(x => x.name === column));
-    if (columnsIndex.some(x => x < 0)) {
-      throw new Error(`Unknown column in ${columns}`);
-    }
-
-    this.index.forEach(i => cb(...columnsIndex.map(columnIndex => this.data[i][columnIndex])));
-  }
-
   // we need this function for table display
   public peak(column: Name) {
     const columnIndex = this.schema.findIndex(x => x.name === column);

--- a/packages/frame/src/stats.ts
+++ b/packages/frame/src/stats.ts
@@ -1,82 +1,62 @@
-/**
- * There was attempt to optimize state for frame,
- * by iterating only twice over frame and calculate all values and memoise the result.
- * Not sure it is the optimal way.
- *
- * TODO: revise this later, as well revise `forEach` method,
- *  maybe it should return row the same way as `map` does.
- */
+import { IteratableFrame, ColumnCursor } from "./types";
 
-import { IteratableFrame } from "./types";
-
-const weakMemoize = <A extends object, B>(func: (a: A) => B) => {
-  const cache = new WeakMap();
-  return (a: A) => {
-    if (!cache.has(a)) {
-      cache.set(a, func(a));
-    }
-    return cache.get(a) as B;
-  };
+type StatsCacheItem = {
+  max?: number;
+  unique?: string[];
 };
 
-const zip = <A extends string, B>(a: A[], b: B[]) =>
-  a.reduce(
-    (acc, x, i) => {
-      acc[x] = b[i];
-      return acc;
-    },
-    {} as Record<A, B>,
-  );
+const statsCache = new WeakMap<
+  IteratableFrame<string>,
+  {
+    [K: number]: StatsCacheItem;
+  }
+>();
 
-type GetQuantitiveStats = <Name extends string>(
+const getStatsCacheItem = <Name extends string>(
   frame: IteratableFrame<Name>,
-) => { min: Record<Name, number>; max: Record<Name, number> };
-
-// For numerical data for now we get min, max. We can get mean, deviation distribution as well
-const getQuantitiveStats: GetQuantitiveStats = weakMemoize(frame => {
-  const quantitiveColumns = frame.schema.filter(column => column.type === "number").map(column => column.name);
-  let max: number[] = [];
-  let min: number[] = [];
-
-  frame.forEach(quantitiveColumns, (...values) => {
-    if (max.length === 0) {
-      max = [...values];
-      min = [...values];
-    } else {
-      values.forEach((value, i) => {
-        max[i] = Math.max(value, max[i]);
-        min[i] = Math.min(value, min[i]);
-      });
-    }
-  });
-
-  return {
-    min: zip(quantitiveColumns, min),
-    max: zip(quantitiveColumns, max),
-  };
-});
-
-type GetCategoricalStats = <Name extends string>(frame: IteratableFrame<Name>) => { unique: Record<Name, string[]> };
-
-const getCategoricalStats: GetCategoricalStats = weakMemoize(frame => {
-  const categoricalColumns = frame.schema.filter(column => column.type === "string").map(column => column.name);
-  const unique: Array<Set<string>> = categoricalColumns.map(() => new Set<string>());
-
-  frame.forEach(categoricalColumns, (...values) => {
-    values.forEach((value, i) => {
-      unique[i].add(value);
-    });
-  });
-
-  return {
-    unique: zip(categoricalColumns, unique.map(x => [...x])),
-  };
-});
-
-export const uniqueValues = <Name extends string>(frame: IteratableFrame<Name>, column: Name): string[] => {
-  return getCategoricalStats(frame).unique[column];
+  column: ColumnCursor<Name>,
+): StatsCacheItem => {
+  if (!statsCache.has(frame)) {
+    statsCache.set(frame, {});
+  }
+  const cacheEntry = statsCache.get(frame)!;
+  if (!cacheEntry[column.index]) {
+    cacheEntry[column.index] = {};
+  }
+  return cacheEntry[column.index];
 };
 
-export const maxValue = <Name extends string>(frame: IteratableFrame<Name>, column: Name): number => {
-  return getQuantitiveStats(frame).max[column];
+export const maxValue = <Name extends string>(frame: IteratableFrame<Name>, column: ColumnCursor<Name>): number => {
+  const cacheItem = getStatsCacheItem(frame, column);
+  if (cacheItem.max === undefined) {
+    // if (process.env.NODE_ENV === "development") {
+    //   if (frame.schema[column.index].type !== "number") {
+    //     console.warn(`Trying to get max value of none-numeric column ${column.name}`);
+    //   }
+    // }
+    // if (frame.length() === 0) {
+    //   throw new Error("Can't get max value of empty Frame")
+    // }
+    let max: number | undefined = undefined;
+    frame.mapRows(row => {
+      max = max === undefined ? row[column.index] : Math.max(max, row[column.index]);
+    });
+    cacheItem.max = max!;
+  }
+  return cacheItem.max!;
+};
+
+export const uniqueValues = <Name extends string>(
+  frame: IteratableFrame<Name>,
+  column: ColumnCursor<Name>,
+): string[] => {
+  const cacheItem = getStatsCacheItem(frame, column);
+  if (cacheItem.unique === undefined) {
+    const unique = new Set<string>();
+    frame.mapRows(row => {
+      unique.add(row[column.index]);
+    });
+    cacheItem.unique = [...unique];
+  }
+  return cacheItem.unique!;
 };

--- a/packages/frame/src/stats.ts
+++ b/packages/frame/src/stats.ts
@@ -1,16 +1,11 @@
 import { IteratableFrame, ColumnCursor } from "./types";
 
-type StatsCacheItem = {
+interface StatsCacheItem {
   max?: number;
   unique?: string[];
-};
+}
 
-const statsCache = new WeakMap<
-  IteratableFrame<string>,
-  {
-    [K: number]: StatsCacheItem;
-  }
->();
+const statsCache = new WeakMap<IteratableFrame<string>, Record<number, StatsCacheItem>>();
 
 const getStatsCacheItem = <Name extends string>(
   frame: IteratableFrame<Name>,

--- a/packages/frame/src/types.ts
+++ b/packages/frame/src/types.ts
@@ -18,7 +18,6 @@ type RawRow = any[];
 
 export interface IteratableFrame<Name extends string> {
   /** needed for stats module */
-  forEach(columns: Name[], cb: (...values: any[]) => void): void;
   readonly schema: Schema<Name>;
   /** needed for visualisations */
   mapRows<Result>(callback: (row: RawRow, index: number) => Result): Result[];

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@operational/grid",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Contiamo visualization library.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -24,7 +24,7 @@
     "react-window": "^1.8.2"
   },
   "peerDependencies": {
-    "@operational/frame": "0.1.0",
+    "@operational/frame": "^0.2.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/packages/grid/src/PivotGrid.tsx
+++ b/packages/grid/src/PivotGrid.tsx
@@ -104,8 +104,8 @@ interface Accessors<Name extends string> {
 }
 
 interface Axes {
-  row?: (rowProps: { row: number; measure?: string, width: number; height: number }) => React.ReactNode;
-  column?: (columnProps: { column: number; measure?: string, width: number; height: number }) => React.ReactNode;
+  row?: React.FC<{ row: number; measure?: string; width: number; height: number }>;
+  column?: React.FC<{ column: number; measure?: string; width: number; height: number }>;
 }
 
 interface PivotGridStyle {
@@ -280,12 +280,22 @@ export const PivotGrid = React.memo(<Name extends string = string>(props: Props<
           break;
         case "RowAxis":
           if (axes.row) {
-            item = axes.row({ row: cellCoordinates.row, measure: cellCoordinates.measure, height, width });
+            item = React.createElement(axes.row, {
+              row: cellCoordinates.row,
+              measure: cellCoordinates.measure,
+              height,
+              width,
+            });
           }
           break;
         case "ColumnAxis":
           if (axes.column) {
-            item = axes.column({ column: cellCoordinates.column, measure: cellCoordinates.measure, height, width });
+            item = React.createElement(axes.column, {
+              column: cellCoordinates.column,
+              measure: cellCoordinates.measure,
+              height,
+              width,
+            });
           }
           break;
         default:

--- a/packages/grid/src/PivotGrid.tsx
+++ b/packages/grid/src/PivotGrid.tsx
@@ -36,7 +36,7 @@ const toString = (value: boolean | string) => {
 
 const defaultCell = <Name extends string = string>({ data, measure }: { data: FragmentFrame<Name>; measure: Name }) => {
   const value = data.peak(measure);
-  return value === null ? null : `${value}`;
+  return value === null ? null : <>{value}</>;
 };
 
 const defaultHeader = ({ value }: { value: string; width: number; height: number }) => (
@@ -81,7 +81,7 @@ type GeneralPivotGridProps<Name extends string> =
         height: number;
         row: number;
         column: number;
-      }) => React.ReactNode;
+      }) => React.ReactElement | null;
     }
   | {
       type: "generalWithMeasures";
@@ -95,7 +95,7 @@ type GeneralPivotGridProps<Name extends string> =
         row: number;
         column: number;
         measure: Name;
-      }) => React.ReactNode;
+      }) => React.ReactElement | null;
     };
 
 interface Accessors<Name extends string> {
@@ -104,8 +104,8 @@ interface Accessors<Name extends string> {
 }
 
 interface Axes {
-  row?: React.FC<{ row: number; measure?: string; width: number; height: number }>;
-  column?: React.FC<{ column: number; measure?: string; width: number; height: number }>;
+  row?: (prop: { row: number; measure?: string; width: number; height: number }) => React.ReactElement | null;
+  column?: (prop: { column: number; measure?: string; width: number; height: number }) => React.ReactElement | null;
 }
 
 interface PivotGridStyle {
@@ -123,7 +123,7 @@ type Props<Name extends string = string> = (TextOnlyPivotGridProps<Name> | Gener
   style?: PivotGridStyle;
   axes?: Axes;
   accessors?: Accessors<Name>;
-  header?: (prop: { value: string; width: number; height: number }) => React.ReactNode;
+  header?: (prop: { value: string; width: number; height: number }) => React.ReactElement | null;
   dimensionLabels?: DimensionLabels | "top" | "left" | "none";
 };
 
@@ -228,7 +228,7 @@ export const PivotGrid = React.memo(<Name extends string = string>(props: Props<
           if (cellCoordinates.dimensionLabel !== undefined) {
             border = { ...headerStyle, ...dimensionStyle, ...border };
             const value = cellCoordinates.dimensionLabel;
-            item = header({ value, height, width });
+            item = React.createElement(header, { value, height, width });
           } else {
             border = { ...headerStyle };
           }
@@ -239,7 +239,7 @@ export const PivotGrid = React.memo(<Name extends string = string>(props: Props<
             ...border,
           };
 
-          item = cell({
+          item = React.createElement(cell, {
             data: data.cell(cellCoordinates.row, cellCoordinates.column),
             measure: cellCoordinates.measure!,
             row: cellCoordinates.row,
@@ -255,11 +255,11 @@ export const PivotGrid = React.memo(<Name extends string = string>(props: Props<
             if (cellCoordinates.rowIndex !== undefined) {
               border = { ...headerStyle, ...border };
               const value = cellCoordinates.label!;
-              item = header({ value, height, width });
+              item = React.createElement(header, { value, height, width });
             } else {
               border = { ...headerStyle, ...dimensionStyle, ...border };
               const value = cellCoordinates.measure!;
-              item = header({ value, height, width });
+              item = React.createElement(header, { value, height, width });
             }
           }
           break;
@@ -270,11 +270,11 @@ export const PivotGrid = React.memo(<Name extends string = string>(props: Props<
             if (cellCoordinates.columnIndex !== undefined) {
               border = { ...headerStyle, ...border };
               const value = cellCoordinates.label!;
-              item = header({ value, height, width });
+              item = React.createElement(header, { value, height, width });
             } else {
               border = { ...headerStyle, ...dimensionStyle, ...border };
               const value = cellCoordinates.measure!;
-              item = header({ value, height, width });
+              item = React.createElement(header, { value, height, width });
             }
           }
           break;

--- a/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
@@ -334,14 +334,19 @@ storiesOf("@operational/grid/1. Pivot table", module)
     });
 
     const Row: React.FC<{ row: number; width: number; height: number }> = ({ row, width, height }) => {
-      const h = height - 2 * padding;
+      const heightWithoutPadding = height - 2 * padding;
       const yScale = useScaleBand({
         frame: pivotedFrame.row(row) as IteratableFrame<string>,
         column: cityCursor,
         range: [0, height],
       });
       return (
-        <svg width={width} height={h} viewBox={`0 0 ${width} ${h}`} style={{ margin: `${padding} 0` }}>
+        <svg
+          width={width}
+          height={heightWithoutPadding}
+          viewBox={`0 0 ${width} ${heightWithoutPadding}`}
+          style={{ margin: `${padding} 0` }}
+        >
           <Axis scale={yScale} transform={`translate(${width}, -${padding})`} position="left" />
         </svg>
       );
@@ -369,20 +374,25 @@ storiesOf("@operational/grid/1. Pivot table", module)
                 "rowIndex" in param || ("measure" in param && param.measure === true) ? 120 : chartWidth,
             }}
             cell={({ data, row, width, height, measure }) => {
-              const w = width - 2 * padding;
-              const h = height - 2 * padding;
+              const widthWithoutPadding = width - 2 * padding;
+              const heightWithoutPadding = height - 2 * padding;
               const yScale = useScaleBand({
                 frame: pivotedFrame.row(row) as IteratableFrame<string>,
                 column: cityCursor,
-                range: [0, h],
+                range: [0, heightWithoutPadding],
               });
               const xScale = useScaleLinear({
                 frame: frame as IteratableFrame<string>,
-                range: [0, w],
+                range: [0, widthWithoutPadding],
                 column: salesCursor,
               });
               return (
-                <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} style={{ margin: padding }}>
+                <svg
+                  width={widthWithoutPadding}
+                  height={heightWithoutPadding}
+                  viewBox={`0 0 ${widthWithoutPadding} ${heightWithoutPadding}`}
+                  style={{ margin: padding }}
+                >
                   <Bars
                     data={data as IteratableFrame<string>}
                     metricScale={xScale}

--- a/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
@@ -326,6 +326,8 @@ storiesOf("@operational/grid/1. Pivot table", module)
     const magicMaxNumberOfBars = 3;
     const barWidth = (chartHeight - padding * 2) / magicMaxNumberOfBars;
 
+    const cityCursor = frame.getCursor("Customer.City");
+    const salesCursor = frame.getCursor("sales");
     const pivotedFrame = frame.pivot({
       rows: ["Customer.Continent", "Customer.Country"],
       columns: ["Customer.AgeGroup", "Customer.Gender"],
@@ -335,7 +337,7 @@ storiesOf("@operational/grid/1. Pivot table", module)
       const h = height - 2 * padding;
       const yScale = useScaleBand({
         frame: pivotedFrame.row(row) as IteratableFrame<string>,
-        column: "Customer.City",
+        column: cityCursor,
         range: [0, height],
       });
       return (
@@ -359,7 +361,7 @@ storiesOf("@operational/grid/1. Pivot table", module)
             accessors={{
               height: param => {
                 if ("row" in param) {
-                  return uniqueValues(pivotedFrame.row(param.row), "Customer.City").length * barWidth + padding * 2;
+                  return uniqueValues(pivotedFrame.row(param.row), cityCursor).length * barWidth + padding * 2;
                 }
                 return "columnIndex" in param || ("measure" in param && param.measure === true) ? 35 : chartHeight;
               },
@@ -371,13 +373,13 @@ storiesOf("@operational/grid/1. Pivot table", module)
               const h = height - 2 * padding;
               const yScale = useScaleBand({
                 frame: pivotedFrame.row(row) as IteratableFrame<string>,
-                column: "Customer.City",
+                column: cityCursor,
                 range: [0, h],
               });
               const xScale = useScaleLinear({
                 frame: frame as IteratableFrame<string>,
                 range: [0, w],
-                column: "sales",
+                column: salesCursor,
               });
               return (
                 <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} style={{ margin: padding }}>

--- a/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
@@ -331,22 +331,20 @@ storiesOf("@operational/grid/1. Pivot table", module)
       columns: ["Customer.AgeGroup", "Customer.Gender"],
     });
 
-    const axes = {
-      row: ({ row, width, height }: { row: number; width: number; height: number }) => {
-        const h = height - 2 * padding;
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const yScale = useScaleBand({
-          frame: pivotedFrame.row(row) as IteratableFrame<string>,
-          column: "Customer.City",
-          range: [0, height],
-        });
-        return (
-          <svg width={width} height={h} viewBox={`0 0 ${width} ${h}`} style={{ margin: `${padding} 0` }}>
-            <Axis scale={yScale} transform={`translate(${width}, -${padding})`} position="left" />
-          </svg>
-        );
-      },
+    const Row: React.FC<{ row: number; width: number; height: number }> = ({ row, width, height }) => {
+      const h = height - 2 * padding;
+      const yScale = useScaleBand({
+        frame: pivotedFrame.row(row) as IteratableFrame<string>,
+        column: "Customer.City",
+        range: [0, height],
+      });
+      return (
+        <svg width={width} height={h} viewBox={`0 0 ${width} ${h}`} style={{ margin: `${padding} 0` }}>
+          <Axis scale={yScale} transform={`translate(${width}, -${padding})`} position="left" />
+        </svg>
+      );
     };
+    const axes = { row: Row };
 
     return (
       <AutoSizer style={{ minHeight: "500px", height: "100%" }}>

--- a/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
@@ -366,7 +366,10 @@ storiesOf("@operational/grid/1. Pivot table", module)
             accessors={{
               height: param => {
                 if ("row" in param) {
-                  return uniqueValues(pivotedFrame.row(param.row), cityCursor).length * barWidth + padding * 2;
+                  // number of bars in bar chart - one bar per unique city
+                  const numberOfBars = uniqueValues(pivotedFrame.row(param.row), cityCursor).length;
+                  // height of the cell is numberOfBars times barWidth plus padding
+                  return numberOfBars * barWidth + padding * 2;
                 }
                 return "columnIndex" in param || ("measure" in param && param.measure === true) ? 35 : chartHeight;
               },

--- a/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
@@ -216,7 +216,7 @@ storiesOf("@operational/grid/1. Pivot table", module)
             style={{
               cell: { padding: "10px", textAlign: "right" },
             }}
-            cell={({ measure }: { measure: string }) => `${measure}`}
+            cell={({ measure }: { measure: string | undefined }) => <>${measure}</>}
           />
         )}
       </AutoSizer>
@@ -241,7 +241,7 @@ storiesOf("@operational/grid/1. Pivot table", module)
             style={{
               cell: { padding: "10px", textAlign: "right" },
             }}
-            cell={({ measure }: { measure: string }) => `${measure}`}
+            cell={({ measure }: { measure: string | undefined }) => <>{measure}</>}
           />
         )}
       </AutoSizer>
@@ -312,7 +312,7 @@ storiesOf("@operational/grid/1. Pivot table", module)
             style={{
               cell: { padding: "10px", textAlign: "right" },
             }}
-            cell={({ measure }: { measure: string }) => `Data for: ${measure}`}
+            cell={({ measure }: { measure: string }) => <>Data for: {measure}</>}
           />
         )}
       </AutoSizer>

--- a/packages/visualizations-stories/src/vizualisations/1-bar-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/1-bar-chart.stories.tsx
@@ -72,12 +72,12 @@ const BarChart = <Name extends string>({
 }: BarChartProps<Name>) => {
   const categoricalScale = useScaleBand({
     frame: data,
-    column: categorical,
+    column: data.getCursor(categorical),
     range: direction === "horizontal" ? [0, height] : [0, width],
   });
   const metricScale = useScaleLinear({
     frame: data,
-    column: metric,
+    column: data.getCursor(metric),
     range: direction === "horizontal" ? [0, width] : [height, 0],
   });
 

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@operational/visualizations",
-  "version": "7.0.8",
+  "version": "7.0.10",
   "description": "Contiamo visualization library.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -26,7 +26,7 @@
     "d3-selection": "^1.3.2"
   },
   "peerDependencies": {
-    "@operational/frame": "0.1.0",
+    "@operational/frame": "^0.2.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/packages/visualizations/src/Axes.md
+++ b/packages/visualizations/src/Axes.md
@@ -135,7 +135,7 @@ For categorical data it needs collect uique values per rows/columns.
 
 ## stats module
 
-To implement stats module we need iterator, for example `forEach(column names)`.
+To implement stats module we need iterator, for example `mapRows()`.
 Also we would need to know types of columns (for quantative and categorical data we need different type of stats).
 
 To implement stats module for pivot table (or multi-index) we can provide following functions:

--- a/packages/visualizations/src/Bars.tsx
+++ b/packages/visualizations/src/Bars.tsx
@@ -16,7 +16,7 @@ export interface BarsProps<Name extends string = string> {
 
 type BarsComponent = <Name extends string>(props: BarsProps<Name>) => React.ReactElement | null;
 
-export const Bars: BarsComponent = React.memo(props => {
+export const Bars: BarsComponent = props => {
   const defaultTransform = useChartTransform();
 
   // TypeScript can't handle this case normally :/
@@ -60,4 +60,4 @@ export const Bars: BarsComponent = React.memo(props => {
       </g>
     );
   }
-});
+};

--- a/packages/visualizations/src/scale.ts
+++ b/packages/visualizations/src/scale.ts
@@ -1,10 +1,10 @@
-import { IteratableFrame, maxValue, uniqueValues } from "@operational/frame";
+import { IteratableFrame, maxValue, uniqueValues, ColumnCursor } from "@operational/frame";
 import { scaleBand, scaleLinear } from "d3-scale";
 import { useMemo } from "react";
 
 export interface ScaleProps<Name extends string> {
   frame: IteratableFrame<Name>;
-  column: Name;
+  column: ColumnCursor<Name>;
   range: [number, number];
   padding?: number;
 }


### PR DESCRIPTION
- Remove one eslint-ignore which I forgot to fix earlier
- Then fix usage of hook inside renderProp (converted render prop to Component), not sure about that decision yet. **Shall we update all render props to be components or remove useScale... hooks**?
- Then rethought implementation of stats module, which relied on types and tried to be over-smart. Simplified logic, removed `forEach` method (which was weird anyway).
- `PivotFrame.cell` method is not referentially transparent, e.g. returns new instance on each call, should we add cache there? Can use https://github.com/lukeed/flru to store pool of frames, so it would be partially referentially transparent, but will less memory requirement

