### PR TITLE
Add pivot frame to grid subcomponents

### DIFF
--- a/packages/frame/package.json
+++ b/packages/frame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@operational/frame",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Contiamo DataFrame.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@operational/grid",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Contiamo visualization library.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/grid/src/PivotGrid.tsx
+++ b/packages/grid/src/PivotGrid.tsx
@@ -77,12 +77,12 @@ const defaultDimensionStyle: React.CSSProperties = {
  * We support text only pivot grid out of the box,
  * for this case you don't need to provide cell render prop, but you need to provide measures
  */
-type TextOnlyPivotGridProps<Name extends string> = {
+interface TextOnlyPivotGridProps<Name extends string> {
   type?: "text";
   measures: Name[];
   /** default value is "column" */
   measuresPlacement?: MeasuresPlacement;
-};
+}
 
 /**
  * This is props for general PivotGrid, you need to provide cell render prop.
@@ -101,23 +101,23 @@ type GeneralPivotGridProps<Name extends string> =
       cell: (prop: CellPropsWithMeasure<Name>) => React.ReactElement | null;
     };
 
-type Accessors<Name extends string> = {
+interface Accessors<Name extends string> {
   width?: WidthAccessor<Name>;
   height?: HeightAccessor<Name>;
-};
+}
 
-type Axes<Name extends string> = {
+interface Axes<Name extends string> {
   row?: (prop: RowProps<Name>) => React.ReactElement | null;
   column?: (prop: ColumnProps<Name>) => React.ReactElement | null;
-};
+}
 
-type PivotGridStyle = {
+interface PivotGridStyle {
   cell?: React.CSSProperties;
   header?: React.CSSProperties;
   dimension?: React.CSSProperties;
   border?: string;
   background?: string;
-};
+}
 
 type Props<Name extends string = string> = (TextOnlyPivotGridProps<Name> | GeneralPivotGridProps<Name>) & {
   width: number;

--- a/packages/grid/src/PivotGrid.tsx
+++ b/packages/grid/src/PivotGrid.tsx
@@ -109,8 +109,8 @@ type GeneralPivotGridProps<Name extends string> =
     };
 
 interface Accessors<Name extends string> {
-  width?: (p: WidthParam<Name>) => number;
-  height?: (p: HeightParam<Name>) => number;
+  width?: (p: WidthParam<Name> & { data: PivotFrame<Name> }) => number;
+  height?: (p: HeightParam<Name> & { data: PivotFrame<Name> }) => number;
 }
 
 interface Axes<Name extends string> {
@@ -216,14 +216,14 @@ export const PivotGrid = React.memo(<Name extends string = string>(props: Props<
 
   const rowHeight = useCallback(
     (rowIndex: number) =>
-      heightAccessors(coordinateToHeightParam(indexToCoordinateMemoised({ rowIndex, columnIndex: 0 }))),
-    [heightAccessors, indexToCoordinateMemoised],
+      heightAccessors({ data, ...coordinateToHeightParam(indexToCoordinateMemoised({ rowIndex, columnIndex: 0 })) }),
+    [heightAccessors, indexToCoordinateMemoised, data],
   );
 
   const columnWidth = useCallback(
     (columnIndex: number) =>
-      widthAccessors(coordinateToWidthParam(indexToCoordinateMemoised({ rowIndex: 0, columnIndex }))),
-    [widthAccessors, indexToCoordinateMemoised],
+      widthAccessors({ data, ...coordinateToWidthParam(indexToCoordinateMemoised({ rowIndex: 0, columnIndex })) }),
+    [widthAccessors, indexToCoordinateMemoised, data],
   );
 
   /**

--- a/packages/grid/src/coordinateUtils.ts
+++ b/packages/grid/src/coordinateUtils.ts
@@ -1,11 +1,11 @@
 import { PivotFrame } from "@operational/frame";
-import { CellCoordinates, DimensionLabels, HeightParam, WidthParam } from "./types";
+import { CellCoordinates, DimensionLabels, HeightParam, WidthParam, MeasuresPlacement } from "./types";
 
 export const exhaustiveCheck = (_: never) => undefined;
 
 export type IndexToCoordinate = <Name extends string = string>(prop: {
   rowHeadersCount: number;
-  measuresPlacement: "row" | "column";
+  measuresPlacement: MeasuresPlacement;
   columnHeadersCount: number;
   measuresCount: number;
   data: PivotFrame<Name>;
@@ -296,14 +296,15 @@ export const coordinateToWidthParam = <Name extends string = string>(prop: CellC
     case "Empty":
       if (prop.measure && prop.rowIndex === undefined) {
         return {
-          measure: true,
+          type: "RowMeasure",
         };
       } else if (prop.axis && prop.rowIndex === undefined) {
         return {
-          axis: true,
+          type: "RowAxis",
         };
       } else {
         return {
+          type: "RowHeader",
           rowIndex: prop.rowIndex!,
         };
       }
@@ -311,21 +312,23 @@ export const coordinateToWidthParam = <Name extends string = string>(prop: CellC
     case "ColumnAxis":
     case "ColumnHeader":
       return {
+        type: "Cell",
         column: prop.column,
         measure: prop.measure,
       };
     case "RowAxis":
       return {
-        axis: true,
+        type: "RowAxis",
       };
     case "RowHeader":
       if (prop.rowIndex !== undefined) {
         return {
+          type: "RowHeader",
           rowIndex: prop.rowIndex,
         };
       } else {
         return {
-          measure: true,
+          type: "RowMeasure",
         };
       }
     default:
@@ -341,14 +344,15 @@ export const coordinateToHeightParam = <Name extends string = string>(
     case "Empty":
       if (prop.measure && prop.columnIndex === undefined) {
         return {
-          measure: true,
+          type: "ColumnMeasure",
         };
       } else if (prop.axis && prop.columnIndex === undefined) {
         return {
-          axis: true,
+          type: "ColumnAxis",
         };
       } else {
         return {
+          type: "ColumnHeader",
           columnIndex: prop.columnIndex!,
         };
       }
@@ -356,21 +360,23 @@ export const coordinateToHeightParam = <Name extends string = string>(
     case "RowAxis":
     case "RowHeader":
       return {
+        type: "Cell",
         row: prop.row,
         measure: prop.measure,
       };
     case "ColumnAxis":
       return {
-        axis: true,
+        type: "ColumnAxis",
       };
     case "ColumnHeader":
       if (prop.columnIndex !== undefined) {
         return {
+          type: "ColumnHeader",
           columnIndex: prop.columnIndex,
         };
       } else {
         return {
-          measure: true,
+          type: "ColumnMeasure",
         };
       }
     default:
@@ -398,7 +404,7 @@ export const getRowHeadersCount = <Name extends string = string>({
   };
   data: PivotFrame<Name>;
   dimensionLabels: DimensionLabels;
-  measuresPlacement: "row" | "column";
+  measuresPlacement: MeasuresPlacement;
   measuresCount: number;
 }) => {
   const rowsDepth = data.getPivotRows().length;
@@ -440,7 +446,7 @@ export const getColumnHeadersCount = <Name extends string = string>({
   };
   data: PivotFrame<Name>;
   dimensionLabels: DimensionLabels;
-  measuresPlacement: "row" | "column";
+  measuresPlacement: MeasuresPlacement;
   measuresCount: number;
 }) => {
   const columnDepth = data.getPivotColumns().length;
@@ -469,7 +475,7 @@ export const getColumnCount = <Name extends string = string>({
   measuresCount,
 }: {
   data: PivotFrame<Name>;
-  measuresPlacement: "row" | "column";
+  measuresPlacement: MeasuresPlacement;
   measuresCount: number;
   rowHeadersCount: number;
 }) => {
@@ -491,7 +497,7 @@ export const getRowCount = <Name extends string = string>({
   measuresCount,
 }: {
   data: PivotFrame<Name>;
-  measuresPlacement: "row" | "column";
+  measuresPlacement: MeasuresPlacement;
   measuresCount: number;
   columnHeadersCount: number;
 }) => {

--- a/packages/grid/src/types.ts
+++ b/packages/grid/src/types.ts
@@ -205,7 +205,7 @@ export type RowProps<Name extends string = string> = {
   width: number;
   height: number;
   row: number;
-  measure?: string;
+  measure?: Name;
 };
 
 export type ColumnProps<Name extends string = string> = {
@@ -213,5 +213,5 @@ export type ColumnProps<Name extends string = string> = {
   width: number;
   height: number;
   column: number;
-  measure?: string;
+  measure?: Name;
 };

--- a/packages/grid/src/types.ts
+++ b/packages/grid/src/types.ts
@@ -175,22 +175,22 @@ export type DimensionLabels =
   | { row: "top" | "left"; column: "none" }
   | { row: "none"; column: "top" | "left" };
 
-export type CellPropsWithoutMeasure<Name extends string = string> = {
+export interface CellPropsWithoutMeasure<Name extends string = string> {
   data: PivotFrame<Name>;
   width: number;
   height: number;
   row: number;
   column: number;
-};
+}
 
-export type CellPropsWithMeasure<Name extends string = string> = {
+export interface CellPropsWithMeasure<Name extends string = string> {
   data: PivotFrame<Name>;
   width: number;
   height: number;
   row: number;
   column: number;
   measure: Name;
-};
+}
 
 export type CellProps<Name extends string = string> = CellPropsWithoutMeasure<Name> | CellPropsWithMeasure<Name>;
 
@@ -200,18 +200,18 @@ export type WidthAccessor<Name extends string = string> = (p: WidthProps<Name>) 
 export type HeightProps<Name extends string = string> = HeightParam<Name> & { data: PivotFrame<Name> };
 export type HeightAccessor<Name extends string = string> = (p: HeightProps<Name>) => number;
 
-export type RowProps<Name extends string = string> = {
+export interface RowProps<Name extends string = string> {
   data: PivotFrame<Name>;
   width: number;
   height: number;
   row: number;
   measure?: Name;
-};
+}
 
-export type ColumnProps<Name extends string = string> = {
+export interface ColumnProps<Name extends string = string> {
   data: PivotFrame<Name>;
   width: number;
   height: number;
   column: number;
   measure?: Name;
-};
+}

--- a/packages/grid/src/types.ts
+++ b/packages/grid/src/types.ts
@@ -1,3 +1,9 @@
+import { PivotFrame } from "@operational/frame";
+
+// we can add "both" in the future https://github.com/contiamo/operational-visualizations/issues/73
+// undefined means "none"
+export type MeasuresPlacement = "row" | "column";
+
 // tslint:disable
 /**
  * ```
@@ -24,18 +30,20 @@ export type WidthParam<Name extends string = string> =
   | {
       // width of an empty cell or a row header
       // this can be row (dimension) name as well
+      type: "RowHeader";
       rowIndex: number;
     }
   | {
       // width of a measure column
-      measure: true;
+      type: "RowMeasure";
     }
   | {
       // width of an axis column
-      axis: true;
+      type: "RowAxis";
     }
   | {
       // width of a column header or a data cell
+      type: "Cell";
       column: number;
       measure?: Name;
     };
@@ -63,18 +71,20 @@ export type HeightParam<Name extends string = string> =
   | {
       // height of an empty cell or a column header
       // this can be column (dimension) name as well
+      type: "ColumnHeader";
       columnIndex: number;
     }
   | {
       // height of a measure column
-      measure: true;
+      type: "ColumnMeasure";
     }
   | {
       // height of an axis column
-      axis: true;
+      type: "ColumnAxis";
     }
   | {
       // height of a row header or a data cell
+      type: "Cell";
       row: number;
       measure?: Name;
     };
@@ -109,6 +119,8 @@ RowHeader -+--------+ |
                       |
 RowAxis --------------+
 ```
+
+TODO: rethink CellCoordinates. Maybe we can remove it in favour of WidthParam & HeightParam
   */
 export type CellCoordinates<Name extends string = string> =
   // tslint:enable
@@ -116,7 +128,7 @@ export type CellCoordinates<Name extends string = string> =
       type: "Empty";
       columnIndex?: number;
       rowIndex?: number;
-      measure?: "row" | "column";
+      measure?: MeasuresPlacement;
       axis?: boolean;
       dimensionLabel?: Name | ""; // empty string is for empty cell
     }
@@ -162,3 +174,44 @@ export type DimensionLabels =
   | { row: "left"; column: "top" }
   | { row: "top" | "left"; column: "none" }
   | { row: "none"; column: "top" | "left" };
+
+export type CellPropsWithoutMeasure<Name extends string = string> = {
+  data: PivotFrame<Name>;
+  width: number;
+  height: number;
+  row: number;
+  column: number;
+};
+
+export type CellPropsWithMeasure<Name extends string = string> = {
+  data: PivotFrame<Name>;
+  width: number;
+  height: number;
+  row: number;
+  column: number;
+  measure: Name;
+};
+
+export type CellProps<Name extends string = string> = CellPropsWithoutMeasure<Name> | CellPropsWithMeasure<Name>;
+
+export type WidthProps<Name extends string = string> = WidthParam<Name> & { data: PivotFrame<Name> };
+export type WidthAccessor<Name extends string = string> = (p: WidthProps<Name>) => number;
+
+export type HeightProps<Name extends string = string> = HeightParam<Name> & { data: PivotFrame<Name> };
+export type HeightAccessor<Name extends string = string> = (p: HeightProps<Name>) => number;
+
+export type RowProps<Name extends string = string> = {
+  data: PivotFrame<Name>;
+  width: number;
+  height: number;
+  row: number;
+  measure?: string;
+};
+
+export type ColumnProps<Name extends string = string> = {
+  data: PivotFrame<Name>;
+  width: number;
+  height: number;
+  column: number;
+  measure?: string;
+};

--- a/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
@@ -1,5 +1,5 @@
-import { DataFrame, uniqueValues, IteratableFrame } from "@operational/frame";
-import { PivotGrid } from "@operational/grid";
+import { DataFrame, uniqueValues } from "@operational/frame";
+import { PivotGrid, RowProps, CellPropsWithMeasure } from "@operational/grid";
 import { Axis, Bars, useScaleBand, useScaleLinear } from "@operational/visualizations";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
@@ -216,7 +216,7 @@ storiesOf("@operational/grid/1. Pivot table", module)
             style={{
               cell: { padding: "10px", textAlign: "right" },
             }}
-            cell={({ measure }: { measure: string | undefined }) => <>${measure}</>}
+            cell={({ measure }: CellPropsWithMeasure) => <>${measure}</>}
           />
         )}
       </AutoSizer>
@@ -241,7 +241,7 @@ storiesOf("@operational/grid/1. Pivot table", module)
             style={{
               cell: { padding: "10px", textAlign: "right" },
             }}
-            cell={({ measure }: { measure: string | undefined }) => <>{measure}</>}
+            cell={({ measure }: CellPropsWithMeasure) => <>{measure}</>}
           />
         )}
       </AutoSizer>
@@ -312,7 +312,7 @@ storiesOf("@operational/grid/1. Pivot table", module)
             style={{
               cell: { padding: "10px", textAlign: "right" },
             }}
-            cell={({ measure }: { measure: string }) => <>Data for: {measure}</>}
+            cell={({ measure }: CellPropsWithMeasure) => <>Data for: {measure}</>}
           />
         )}
       </AutoSizer>
@@ -333,16 +333,10 @@ storiesOf("@operational/grid/1. Pivot table", module)
       columns: ["Customer.AgeGroup", "Customer.Gender"],
     });
 
-    // TODO: we need some utility to not have to redeclare types here
-    const Row: React.FC<{ row: number; width: number; height: number; data: typeof pivotedFrame }> = ({
-      row,
-      width,
-      height,
-      data,
-    }) => {
+    const Row: React.FC<RowProps> = ({ row, width, height, data }) => {
       const heightWithoutPadding = height - 2 * padding;
       const yScale = useScaleBand({
-        frame: data.row(row) as IteratableFrame<string>,
+        frame: data.row(row),
         column: cityCursor,
         range: [0, height],
       });

--- a/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
@@ -376,16 +376,16 @@ storiesOf("@operational/grid/1. Pivot table", module)
               width: param =>
                 "rowIndex" in param || ("measure" in param && param.measure === true) ? 120 : chartWidth,
             }}
-            cell={({ data, row, width, height, measure }) => {
+            cell={({ data, row, column, width, height, measure }) => {
               const widthWithoutPadding = width - 2 * padding;
               const heightWithoutPadding = height - 2 * padding;
               const yScale = useScaleBand({
-                frame: pivotedFrame.row(row) as IteratableFrame<string>,
+                frame: data.row(row),
                 column: cityCursor,
                 range: [0, heightWithoutPadding],
               });
               const xScale = useScaleLinear({
-                frame: frame as IteratableFrame<string>,
+                frame: data.unpivot(),
                 range: [0, widthWithoutPadding],
                 column: salesCursor,
               });
@@ -397,7 +397,7 @@ storiesOf("@operational/grid/1. Pivot table", module)
                   style={{ margin: padding }}
                 >
                   <Bars
-                    data={data as IteratableFrame<string>}
+                    data={data.cell(row, column)}
                     metricScale={xScale}
                     categoricalScale={yScale}
                     metric={frame.getCursor(measure)}

--- a/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
@@ -333,10 +333,16 @@ storiesOf("@operational/grid/1. Pivot table", module)
       columns: ["Customer.AgeGroup", "Customer.Gender"],
     });
 
-    const Row: React.FC<{ row: number; width: number; height: number }> = ({ row, width, height }) => {
+    // TODO: we need some utility to not have to redeclare types here
+    const Row: React.FC<{ row: number; width: number; height: number; data: typeof pivotedFrame }> = ({
+      row,
+      width,
+      height,
+      data,
+    }) => {
       const heightWithoutPadding = height - 2 * padding;
       const yScale = useScaleBand({
-        frame: pivotedFrame.row(row) as IteratableFrame<string>,
+        frame: data.row(row) as IteratableFrame<string>,
         column: cityCursor,
         range: [0, height],
       });
@@ -367,7 +373,7 @@ storiesOf("@operational/grid/1. Pivot table", module)
               height: param => {
                 if ("row" in param) {
                   // number of bars in bar chart - one bar per unique city
-                  const numberOfBars = uniqueValues(pivotedFrame.row(param.row), cityCursor).length;
+                  const numberOfBars = uniqueValues(param.data.row(param.row), cityCursor).length;
                   // height of the cell is numberOfBars times barWidth plus padding
                   return numberOfBars * barWidth + padding * 2;
                 }

--- a/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
@@ -371,16 +371,16 @@ storiesOf("@operational/grid/1. Pivot table", module)
             data={pivotedFrame}
             accessors={{
               height: param => {
-                if ("row" in param) {
+                if (param.type === "Cell") {
                   // number of bars in bar chart - one bar per unique city
                   const numberOfBars = uniqueValues(param.data.row(param.row), cityCursor).length;
                   // height of the cell is numberOfBars times barWidth plus padding
                   return numberOfBars * barWidth + padding * 2;
+                } else {
+                  return 35;
                 }
-                return "columnIndex" in param || ("measure" in param && param.measure === true) ? 35 : chartHeight;
               },
-              width: param =>
-                "rowIndex" in param || ("measure" in param && param.measure === true) ? 120 : chartWidth,
+              width: param => (param.type === "Cell" ? chartWidth : 120),
             }}
             cell={({ data, row, column, width, height, measure }) => {
               const widthWithoutPadding = width - 2 * padding;

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@operational/visualizations",
-  "version": "7.0.11",
+  "version": "7.0.12",
   "description": "Contiamo visualization library.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/visualizations/src/Area.tsx
+++ b/packages/visualizations/src/Area.tsx
@@ -2,11 +2,10 @@ import { area } from "d3-shape";
 import React from "react";
 import { useChartTransform } from "./Chart";
 import { AxialChart } from "./types";
-import { getStyleProp } from "./utils";
+import { isFunction } from "./utils";
 
 export const Area: AxialChart<string> = React.memo(props => {
   const defaultTransform = useChartTransform();
-  const styleProp = getStyleProp(props.style);
 
   const { metricDirection, data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
 
@@ -24,17 +23,14 @@ export const Area: AxialChart<string> = React.memo(props => {
 
   const path =
     area()
-      .x0(d => metricDirection === "vertical" ? d[0] : metricScale.range()[0])
+      .x0(d => (metricDirection === "vertical" ? d[0] : metricScale.range()[0]))
       .x1(d => d[0])
-      .y0(d => metricDirection === "vertical" ? metricScale.range()[0] : d[1])
+      .y0(d => (metricDirection === "vertical" ? metricScale.range()[0] : d[1]))
       .y1(d => d[1])(pathData) || "";
 
   return (
     <g transform={transform || defaultTransform}>
-      <path
-        d={path}
-        style={ styleProp.isFunction ? styleProp.style(0) : style as React.CSSProperties }
-      />
+      <path d={path} style={isFunction(style) ? style(0) : style} />
     </g>
   );
 });

--- a/packages/visualizations/src/Bars.tsx
+++ b/packages/visualizations/src/Bars.tsx
@@ -1,14 +1,13 @@
 import React from "react";
 import { useChartTransform } from "./Chart";
 import { AxialChart } from "./types";
-import { getStyleProp } from "./utils";
+import { isFunction } from "./utils";
 
 export const Bars: AxialChart<string> = props => {
   const defaultTransform = useChartTransform();
-  const styleProp = getStyleProp(props.style);
 
   if (props.metricDirection === "vertical") {
-    const { data, transform, metric, categorical, metricScale, categoricalScale } = props;
+    const { data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
     const height = metricScale(metricScale.domain()[0]);
 
     return (
@@ -19,14 +18,14 @@ export const Bars: AxialChart<string> = props => {
             y={metricScale(metric(row))}
             width={categoricalScale.bandwidth()}
             height={height - metricScale(metric(row))}
-            style={styleProp.isFunction ? styleProp.style(i) : styleProp.style}
+            style={isFunction(style) ? style(i) : style}
             key={i}
           />
         ))}
       </g>
     );
   } else {
-    const { data, transform, metric, categorical, metricScale, categoricalScale } = props;
+    const { data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
     return (
       <g transform={transform || defaultTransform}>
         {data.mapRows((row, i) => (
@@ -35,7 +34,7 @@ export const Bars: AxialChart<string> = props => {
             x={0}
             height={categoricalScale.bandwidth()}
             width={metricScale(metric(row))}
-            style={styleProp.isFunction ? styleProp.style(i) : styleProp.style}
+            style={isFunction(style) ? style(i) : style}
             key={i}
           />
         ))}

--- a/packages/visualizations/src/Line.tsx
+++ b/packages/visualizations/src/Line.tsx
@@ -2,11 +2,10 @@ import { line } from "d3-shape";
 import React from "react";
 import { useChartTransform } from "./Chart";
 import { AxialChart } from "./types";
-import { getStyleProp } from "./utils";
+import { isFunction } from "./utils";
 
 export const Line: AxialChart<string> = React.memo(props => {
   const defaultTransform = useChartTransform();
-  const styleProp = getStyleProp(props.style);
 
   const { metricDirection, data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
 
@@ -33,7 +32,7 @@ export const Line: AxialChart<string> = React.memo(props => {
         d={path}
         style={{
           fill: "none",
-          ...(styleProp.isFunction ? styleProp.style(0) : style),
+          ...(isFunction(style) ? style(0) : style),
         }}
       />
     </g>

--- a/packages/visualizations/src/utils.ts
+++ b/packages/visualizations/src/utils.ts
@@ -1,5 +1,3 @@
-import { AxialChartProps } from "./types";
-
-// TypeScript can't handle this case normally :/
-export const getStyleProp = (style: AxialChartProps<string>["style"]) =>
-  typeof style === "function" ? { isFunction: true as true, style } : { isFunction: false as false, style };
+export const isFunction = (x: any): x is Function => {
+  return !!(x && x.constructor && x.call && x.apply);
+};

--- a/packages/visualizations/src/utils.ts
+++ b/packages/visualizations/src/utils.ts
@@ -1,3 +1,1 @@
-export const isFunction = (x: any): x is Function => {
-  return !!(x && x.constructor && x.call && x.apply);
-};
+export const isFunction = (x: any): x is Function => x instanceof Function;


### PR DESCRIPTION
Some changes to API to make it more usable

- exposed some types which were not exposed earlier
- add data to every sub-component, like cell and row etc.
- refactored `HeightParam` and `WidthParam` to make it more usable