### PR TITLE
Stacked bar charts.

### DIFF
--- a/packages/frame/src/index.ts
+++ b/packages/frame/src/index.ts
@@ -5,3 +5,4 @@ export { DataFrame } from "./DataFrame";
 export { PivotFrame } from "./PivotFrame";
 export { PivotFramePreindexed } from "./PivotFramePreindexed";
 export { FragmentFrame } from "./FragmentFrame";
+export { stackRowBy } from "./utils";

--- a/packages/frame/src/stats.ts
+++ b/packages/frame/src/stats.ts
@@ -69,16 +69,7 @@ export const uniqueValueCombinations = <Name extends string>(
   frame: IterableFrame<Name>,
   columns: Array<ColumnCursor<Name>>,
 ): Array<string[]> => {
-  const columnValues = columns.map(c => uniqueValues(frame, c))
-
-  const combineValues = (i: number, values: string[]): Array<string[]> => {
-    return i === columns.length - 1
-      ? columnValues[i].map(val => [...values, val])
-      : columnValues[i].reduce((arr: Array<string[]>, val) => {
-          return [...arr, ...combineValues(i + 1, [...values, val])]
-        }, [])
-  }
-
-  return combineValues(0, [])
+  const valueCombinations = frame.mapRows(row => columns.map(cursor => cursor(row)));
+  return Array.from(new Set(valueCombinations.map(combo => JSON.stringify(combo)))).map(s => JSON.parse(s));
 }
 

--- a/packages/frame/src/utils.ts
+++ b/packages/frame/src/utils.ts
@@ -4,13 +4,10 @@ export const isCursor = (x: any): x is ColumnCursor<any> =>
   (!!x.index || x.index === 0) && x instanceof Function;
 
 export const stackRowBy = <Name extends string>(categorical: ColumnCursor<Name>, metric: ColumnCursor<Name>) => {
-  let value = 0;
-  let prevRow: RawRow;
+  let prev: Record<string, number> = {};
   return (row: RawRow) => {
-    value = prevRow && categorical(prevRow) === categorical(row)
-      ? value + metric(prevRow)
-      : 0;
-    prevRow = row;
+    const value = prev[categorical(row)] || 0;
+    prev[categorical(row)] = value + metric(row);
     return value
   }
-}
+};

--- a/packages/frame/src/utils.ts
+++ b/packages/frame/src/utils.ts
@@ -1,4 +1,16 @@
-import { ColumnCursor } from "./types";
+import { ColumnCursor, RawRow } from "./types";
 
 export const isCursor = (x: any): x is ColumnCursor<any> =>
   (!!x.index || x.index === 0) && x instanceof Function;
+
+export const stackRowBy = <Name extends string>(categorical: ColumnCursor<Name>, metric: ColumnCursor<Name>) => {
+  let value = 0;
+  let prevRow: RawRow;
+  return (row: RawRow) => {
+    value = prevRow && categorical(prevRow) === categorical(row)
+      ? value + metric(prevRow)
+      : 0;
+    prevRow = row;
+    return value
+  }
+}

--- a/packages/visualizations-stories/src/vizualisations/1-bar-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/1-bar-chart.stories.tsx
@@ -83,14 +83,17 @@ const BarChart = <Name extends string>({
   metric,
   metricDirection,
 }: BarChartProps<Name>) => {
+  const categoricalCursor = data.getCursor(categorical);
+  const metricCursor = data.getCursor(metric);
   const categoricalScale = useScaleBand({
     frame: data,
-    column: data.getCursor(categorical),
+    column: categoricalCursor,
     range: metricDirection === "horizontal" ? [0, height] : [0, width],
   });
   const metricScale = useScaleLinear({
     frame: data,
-    column: data.getCursor(metric),
+    column: metricCursor,
+    categorical: categoricalCursor,
     range: metricDirection === "horizontal" ? [0, width] : [height, 0],
   });
   const colorCursor = data.getCursor("Customer.Country" as Name);
@@ -100,8 +103,8 @@ const BarChart = <Name extends string>({
       <Bars
         metricDirection={metricDirection}
         data={data}
-        categorical={data.getCursor(categorical)}
-        metric={data.getCursor(metric)}
+        categorical={categoricalCursor}
+        metric={metricCursor}
         categoricalScale={categoricalScale}
         metricScale={metricScale}
         style={row => ({ fill: colors[colorCursor(row) as "Germany" | "UK" | "USA" | "Canada"] })}
@@ -136,6 +139,36 @@ storiesOf("@operational/visualizations/1. Bar chart", module)
       <BarChart
         metric="sales"
         categorical="Customer.City"
+        width={300}
+        height={300}
+        margin={magicMargin}
+        data={frame}
+        metricDirection="vertical"
+      />
+    );
+  })
+  .add("stacked horizontal", () => {
+    // number of pixels picked manually to make sure that YAxis fits on the screen
+    const magicMargin = 60;
+    return (
+      <BarChart
+        metric="sales"
+        categorical="Customer.Country"
+        width={300}
+        height={300}
+        margin={magicMargin}
+        data={frame}
+        metricDirection="horizontal"
+      />
+    );
+  })
+  .add("stacked vertical", () => {
+    // number of pixels picked manually to make sure that YAxis fits on the screen
+    const magicMargin = 60;
+    return (
+      <BarChart
+        metric="sales"
+        categorical="Customer.Country"
         width={300}
         height={300}
         margin={magicMargin}

--- a/packages/visualizations/src/Bars.tsx
+++ b/packages/visualizations/src/Bars.tsx
@@ -2,56 +2,43 @@ import React from "react";
 import { useChartTransform } from "./Chart";
 import { DiscreteAxialChart } from "./types";
 import { isFunction } from "./utils";
-import { RawRow } from "@operational/frame";
+import { stackRowBy } from "@operational/frame";
 
 export const Bars: DiscreteAxialChart<string> = props => {
   const defaultTransform = useChartTransform();
   const { data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
-  let value = 0;
-  let prevRow: RawRow;
-  const stackRow = (row: RawRow) => {
-    value =
-      prevRow && categorical(prevRow) === categorical(row)
-        ? value + metric(prevRow)
-        : 0;
-    prevRow = row;
-  };
+
+  const stackRow = stackRowBy(categorical, metric)
 
   if (props.metricDirection === "vertical") {
     const height = metricScale(metricScale.domain()[0]);
     return (
       <g transform={transform || defaultTransform}>
-        {data.mapRows((row, i) => {
-          stackRow(row);
-          return (
-            <rect
-              x={categoricalScale(categorical(row))}
-              y={metricScale(metric(row) + value)}
-              width={categoricalScale.bandwidth()}
-              height={height - metricScale(metric(row))}
-              style={isFunction(style) ? style(row, i) : style}
-              key={i}
-            />
-          );
-        })}
+        {data.mapRows((row, i) =>
+          <rect
+            x={categoricalScale(categorical(row))}
+            y={metricScale(metric(row) + stackRow(row))}
+            width={categoricalScale.bandwidth()}
+            height={height - metricScale(metric(row))}
+            style={isFunction(style) ? style(row, i) : style}
+            key={i}
+          />
+        )}
       </g>
     );
   } else {
     return (
       <g transform={transform || defaultTransform}>
-        {data.mapRows((row, i) => {
-          stackRow(row);
-          return (
-            <rect
-              y={categoricalScale(categorical(row))}
-              x={metricScale(value)}
-              height={categoricalScale.bandwidth()}
-              width={metricScale(metric(row))}
-              style={isFunction(style) ? style(row, i) : style}
-              key={i}
-            />
-          );
-        })}
+        {data.mapRows((row, i) =>
+          <rect
+            y={categoricalScale(categorical(row))}
+            x={metricScale(stackRow(row))}
+            height={categoricalScale.bandwidth()}
+            width={metricScale(metric(row))}
+            style={isFunction(style) ? style(row, i) : style}
+            key={i}
+          />
+        )}
       </g>
     );
   }

--- a/packages/visualizations/src/Bars.tsx
+++ b/packages/visualizations/src/Bars.tsx
@@ -2,42 +2,56 @@ import React from "react";
 import { useChartTransform } from "./Chart";
 import { DiscreteAxialChart } from "./types";
 import { isFunction } from "./utils";
+import { RawRow } from "@operational/frame";
 
 export const Bars: DiscreteAxialChart<string> = props => {
   const defaultTransform = useChartTransform();
+  const { data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
+  let value = 0;
+  let prevRow: RawRow;
+  const stackRow = (row: RawRow) => {
+    value =
+      prevRow && categorical(prevRow) === categorical(row)
+        ? value + metric(prevRow)
+        : 0;
+    prevRow = row;
+  };
 
   if (props.metricDirection === "vertical") {
-    const { data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
     const height = metricScale(metricScale.domain()[0]);
-
     return (
       <g transform={transform || defaultTransform}>
-        {data.mapRows((row, i) => (
-          <rect
-            x={categoricalScale(categorical(row))}
-            y={metricScale(metric(row))}
-            width={categoricalScale.bandwidth()}
-            height={height - metricScale(metric(row))}
-            style={isFunction(style) ? style(row, i) : style}
-            key={i}
-          />
-        ))}
+        {data.mapRows((row, i) => {
+          stackRow(row);
+          return (
+            <rect
+              x={categoricalScale(categorical(row))}
+              y={metricScale(metric(row) + value)}
+              width={categoricalScale.bandwidth()}
+              height={height - metricScale(metric(row))}
+              style={isFunction(style) ? style(row, i) : style}
+              key={i}
+            />
+          );
+        })}
       </g>
     );
   } else {
-    const { data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
     return (
       <g transform={transform || defaultTransform}>
-        {data.mapRows((row, i) => (
-          <rect
-            y={categoricalScale(categorical(row))}
-            x={0}
-            height={categoricalScale.bandwidth()}
-            width={metricScale(metric(row))}
-            style={isFunction(style) ? style(row, i) : style}
-            key={i}
-          />
-        ))}
+        {data.mapRows((row, i) => {
+          stackRow(row);
+          return (
+            <rect
+              y={categoricalScale(categorical(row))}
+              x={metricScale(value)}
+              height={categoricalScale.bandwidth()}
+              width={metricScale(metric(row))}
+              style={isFunction(style) ? style(row, i) : style}
+              key={i}
+            />
+          );
+        })}
       </g>
     );
   }

--- a/packages/visualizations/src/Bars.tsx
+++ b/packages/visualizations/src/Bars.tsx
@@ -2,13 +2,10 @@ import React from "react";
 import { useChartTransform } from "./Chart";
 import { DiscreteAxialChart } from "./types";
 import { isFunction } from "./utils";
-import { stackRowBy } from "@operational/frame";
 
 export const Bars: DiscreteAxialChart<string> = props => {
   const defaultTransform = useChartTransform();
-  const { data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
-
-  const stackRow = stackRowBy(categorical, metric)
+  const { data, transform, metric, categorical, metricScale, categoricalScale, stackRow, style } = props;
 
   if (props.metricDirection === "vertical") {
     const height = metricScale(metricScale.domain()[0]);
@@ -17,7 +14,7 @@ export const Bars: DiscreteAxialChart<string> = props => {
         {data.mapRows((row, i) =>
           <rect
             x={categoricalScale(categorical(row))}
-            y={metricScale(metric(row) + stackRow(row))}
+            y={metricScale(metric(row) + (stackRow ? stackRow(row) : 0))}
             width={categoricalScale.bandwidth()}
             height={height - metricScale(metric(row))}
             style={isFunction(style) ? style(row, i) : style}
@@ -32,7 +29,7 @@ export const Bars: DiscreteAxialChart<string> = props => {
         {data.mapRows((row, i) =>
           <rect
             y={categoricalScale(categorical(row))}
-            x={metricScale(stackRow(row))}
+            x={metricScale((stackRow ? stackRow(row) : 0))}
             height={categoricalScale.bandwidth()}
             width={metricScale(metric(row))}
             style={isFunction(style) ? style(row, i) : style}

--- a/packages/visualizations/src/scale.ts
+++ b/packages/visualizations/src/scale.ts
@@ -9,6 +9,10 @@ export interface ScaleProps<Name extends string> {
   padding?: number;
 }
 
+type LinearScaleProps<Name extends string> = ScaleProps<Name> & {
+  categorical?: ColumnCursor<Name>;
+};
+
 /**
  * Takes `frame`, `column` (values in the column supposed to be strings) and `size` of container and
  * returns ScaleBand
@@ -23,14 +27,14 @@ export const getScaleBand = <Name extends string>({ frame, column, range, paddin
  * Takes `frame`, `column` (values in the column supposed to be numbers) and `size` of container and
  * returns ScaleLinear
  */
-export const getScaleLinear = <Name extends string>({ frame, column, range }: ScaleProps<Name>) =>
+export const getScaleLinear = <Name extends string>({ frame, column, range, categorical }: LinearScaleProps<Name>) =>
   scaleLinear()
-    .domain([0, maxValue(frame, column)])
+    .domain([0, maxValue(frame, column, categorical)])
     .range(range);
 
 // Hook versions for convenience
 export const useScaleBand = <Name extends string>({ frame, column, range, padding }: ScaleProps<Name>) =>
   useMemo(() => getScaleBand({ frame, column, range, padding }), [frame, column, range, padding]);
 
-export const useScaleLinear = <Name extends string>({ frame, column, range }: ScaleProps<Name>) =>
-  useMemo(() => getScaleLinear({ frame, column, range }), [frame, column, range]);
+export const useScaleLinear = <Name extends string>({ frame, column, range, categorical }: LinearScaleProps<Name>) =>
+  useMemo(() => getScaleLinear({ frame, column, range, categorical }), [frame, column, range, categorical]);

--- a/packages/visualizations/src/types.ts
+++ b/packages/visualizations/src/types.ts
@@ -8,6 +8,7 @@ export interface BaseAxialChartProps<Name extends string> {
   categorical: ColumnCursor<Name>;
   metricScale: ScaleLinear<any, any>;
   categoricalScale: ScaleBand<string>;
+  stackRow?: (row: RawRow[]) => number;
   transform?: React.SVGAttributes<SVGRectElement>["transform"];
 }
 


### PR DESCRIPTION
Similar approach to #83 but without passing `prevRow` as argument through `mapRows` (I feel like this is inconsistent with how map functions normally behave), and based off most recent version of master.

Includes axis adjustments to account for stacking. 