### PR TITLE
Add groupBy method to data frames.

### DIFF
--- a/packages/frame/package.json
+++ b/packages/frame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@operational/frame",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Contiamo DataFrame.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/frame/src/DataFrame.ts
+++ b/packages/frame/src/DataFrame.ts
@@ -42,10 +42,10 @@ export class DataFrame<Name extends string = string> implements IteratableFrame<
     return this.cursorCache.get(column)!;
   }
 
-  public groupBy(columns: Array<Name | ColumnCursor<Name>>): Array<FragmentFrame<Name>> {
-    // If no columns are provided, returns an array with the current frame as a FragmentFrame as the sole entry.
+  public groupBy(columns: Array<Name | ColumnCursor<Name>>): Array<IteratableFrame<Name>> {
+    // If no columns are provided, returns an array with the current frame as the sole entry.
     if (columns.length === 0) {
-      return [new FragmentFrame<Name>(this, this.data.map((_, i) => i))];
+      return [this];
     }
 
     const columnCursors = columns.map(c => isCursor(c) ? c : this.getCursor(c))

--- a/packages/frame/src/DataFrame.ts
+++ b/packages/frame/src/DataFrame.ts
@@ -43,7 +43,13 @@ export class DataFrame<Name extends string = string> implements IteratableFrame<
   }
 
   public groupBy(columns: Array<Name | ColumnCursor<Name>>): Array<FragmentFrame<Name>> {
+    // If no columns are provided, returns an array with the current frame as a FragmentFrame as the sole entry.
+    if (columns.length === 0) {
+      return [new FragmentFrame<Name>(this, this.data.map((_, i) => i))];
+    }
+
     const columnCursors = columns.map(c => isCursor(c) ? c : this.getCursor(c))
+    // Returns a FragmentFrame for every unique combination of column values.
     return uniqueValueCombinations(this, columnCursors).map(u => {
       const indices = this.data.reduce((arr, row, i): any => {
         if (columnCursors.every((cursor, j) => cursor(row) === u[j])) {
@@ -53,7 +59,7 @@ export class DataFrame<Name extends string = string> implements IteratableFrame<
       }, [])
 
       return new FragmentFrame<Name>(this, indices)
-      })
+    })
   }
 
   public mapRows<A>(callback: (row: RawRow[], index: number) => A) {

--- a/packages/frame/src/FragmentFrame.ts
+++ b/packages/frame/src/FragmentFrame.ts
@@ -1,6 +1,6 @@
 // this is not circular dependency, because we use DataFrame as type
 import { DataFrame } from "./DataFrame";
-import { IteratableFrame, WithCursor, RawRow, ColumnCursor, Matrix, Schema } from "./types";
+import { IteratableFrame, WithColumnMethods, RawRow, ColumnCursor, Matrix, Schema } from "./types";
 import { getData } from "./secret";
 
 const isColumnCursor = <Name extends string>(column: any): column is ColumnCursor<Name> => {
@@ -11,7 +11,7 @@ export class FragmentFrame<Name extends string = string> implements IteratableFr
   private readonly data: Matrix<any>;
   public readonly schema: Schema<Name>;
   private readonly index: number[];
-  private readonly origin: WithCursor<Name>;
+  private readonly origin: WithColumnMethods<Name>;
 
   constructor(origin: DataFrame<Name>, index: number[]) {
     this.origin = origin;
@@ -23,6 +23,10 @@ export class FragmentFrame<Name extends string = string> implements IteratableFr
 
   public getCursor(column: Name) {
     return this.origin.getCursor(column);
+  }
+
+  public groupBy(columns: Array<Name | ColumnCursor<Name>>) {
+    return this.origin.groupBy(columns)
   }
 
   public mapRows<A>(callback: (row: RawRow, index: number) => A) {

--- a/packages/frame/src/FragmentFrame.ts
+++ b/packages/frame/src/FragmentFrame.ts
@@ -27,7 +27,7 @@ export class FragmentFrame<Name extends string = string> implements IteratableFr
     return this.origin.getCursor(column);
   }
 
-  public groupBy(columns: Array<Name | ColumnCursor<Name>>): Array<FragmentFrame<Name>> {
+  public groupBy(columns: Array<Name | ColumnCursor<Name>>): Array<IteratableFrame<Name>> {
     // If no columns are provided, returns an array with the current frame as a FragmentFrame as the sole entry.
     if (columns.length === 0) {
       return [this];

--- a/packages/frame/src/FragmentFrame.ts
+++ b/packages/frame/src/FragmentFrame.ts
@@ -1,6 +1,6 @@
 // this is not circular dependency, because we use DataFrame as type
 import { DataFrame } from "./DataFrame";
-import { IteratableFrame, WithColumnMethods, RawRow, ColumnCursor, Matrix, Schema } from "./types";
+import { IteratableFrame, RawRow, ColumnCursor, Matrix, Schema } from "./types";
 import { getData } from "./secret";
 
 const isColumnCursor = <Name extends string>(column: any): column is ColumnCursor<Name> => {
@@ -11,7 +11,7 @@ export class FragmentFrame<Name extends string = string> implements IteratableFr
   private readonly data: Matrix<any>;
   public readonly schema: Schema<Name>;
   private readonly index: number[];
-  private readonly origin: WithColumnMethods<Name>;
+  private readonly origin: DataFrame<Name>;
 
   constructor(origin: DataFrame<Name>, index: number[]) {
     this.origin = origin;
@@ -25,7 +25,7 @@ export class FragmentFrame<Name extends string = string> implements IteratableFr
     return this.origin.getCursor(column);
   }
 
-  public groupBy(columns: Array<Name | ColumnCursor<Name>>) {
+  public groupBy(columns: Array<Name> | Array<ColumnCursor<Name>>) {
     return this.origin.groupBy(columns)
   }
 

--- a/packages/frame/src/PivotFrame.ts
+++ b/packages/frame/src/PivotFrame.ts
@@ -1,7 +1,7 @@
 // this is not circular dependency, because we use DataFrame as type
 import { DataFrame } from "./DataFrame";
 import { FragmentFrame } from "./FragmentFrame";
-import { PivotProps, WithCursor, Matrix, Schema } from "./types";
+import { PivotProps, WithColumnMethods, Matrix, Schema, ColumnCursor } from "./types";
 import { getData } from "./secret";
 
 const intersect = <T>(...arr: T[][]): T[] => arr.reduce((prev, curr) => prev.filter(x => curr.includes(x)));
@@ -9,7 +9,7 @@ const intersect = <T>(...arr: T[][]): T[] => arr.reduce((prev, curr) => prev.fil
 // theoretically it can be string | bool | number, but TS doesn't allow to use bool as index value
 export type DimensionValue = string;
 
-export class PivotFrame<Name extends string = string> implements WithCursor<Name> {
+export class PivotFrame<Name extends string = string> implements WithColumnMethods<Name> {
   private readonly data: Matrix<any>;
   private readonly schema: Schema<Name>;
   private readonly prop: PivotProps<Name, Name>;
@@ -67,6 +67,10 @@ export class PivotFrame<Name extends string = string> implements WithCursor<Name
   public columnHeaders() {
     this.buildIndex();
     return this.columnHeadersInternal;
+  }
+
+  public groupBy(columns: Array<Name | ColumnCursor<Name>>) {
+    return this.origin.groupBy(columns)
   }
 
   public row(rowIdentifier: number) {

--- a/packages/frame/src/PivotFrame.ts
+++ b/packages/frame/src/PivotFrame.ts
@@ -1,7 +1,7 @@
 // this is not circular dependency, because we use DataFrame as type
 import { DataFrame } from "./DataFrame";
 import { FragmentFrame } from "./FragmentFrame";
-import { PivotProps, WithColumnMethods, Matrix, Schema, ColumnCursor } from "./types";
+import { PivotProps, WithCursor, Matrix, Schema } from "./types";
 import { getData } from "./secret";
 
 const intersect = <T>(...arr: T[][]): T[] => arr.reduce((prev, curr) => prev.filter(x => curr.includes(x)));
@@ -9,7 +9,7 @@ const intersect = <T>(...arr: T[][]): T[] => arr.reduce((prev, curr) => prev.fil
 // theoretically it can be string | bool | number, but TS doesn't allow to use bool as index value
 export type DimensionValue = string;
 
-export class PivotFrame<Name extends string = string> implements WithColumnMethods<Name> {
+export class PivotFrame<Name extends string = string> implements WithCursor<Name> {
   private readonly data: Matrix<any>;
   private readonly schema: Schema<Name>;
   private readonly prop: PivotProps<Name, Name>;
@@ -67,10 +67,6 @@ export class PivotFrame<Name extends string = string> implements WithColumnMetho
   public columnHeaders() {
     this.buildIndex();
     return this.columnHeadersInternal;
-  }
-
-  public groupBy(columns: Array<Name | ColumnCursor<Name>>) {
-    return this.origin.groupBy(columns)
   }
 
   public row(rowIdentifier: number) {

--- a/packages/frame/src/stats.ts
+++ b/packages/frame/src/stats.ts
@@ -56,3 +56,21 @@ export const uniqueValues = <Name extends string>(
   }
   return cacheItem.unique!;
 };
+
+export const uniqueValueCombinations = <Name extends string>(
+  frame: IteratableFrame<Name>,
+  columns: Array<ColumnCursor<Name>>,
+): Array<string[]> => {
+  const columnValues = columns.map(c => uniqueValues(frame, c))
+
+  const combineValues = (i: number, values: string[]): Array<string[]> => {
+    return i === columns.length - 1
+      ? columnValues[i].map(val => [...values, val])
+      : columnValues[i].reduce((arr: Array<string[]>, val) => {
+          return [...arr, ...combineValues(i + 1, [...values, val])]
+        }, [])
+  }
+
+  return combineValues(0, [])
+}
+

--- a/packages/frame/src/types.ts
+++ b/packages/frame/src/types.ts
@@ -1,3 +1,5 @@
+import { DataFrame } from "./DataFrame";
+
 /**
  * Can represent array of arrays or list of tuples or tuple of lists
  */
@@ -16,15 +18,19 @@ export type Schema<Name extends string> = Array<{ name: Name; type?: any }>;
  */
 export type RawRow = any[];
 
-export interface WithCursor<Name extends string> {
+export interface WithColumnMethods<Name extends string> {
   getCursor(column: Name): ColumnCursor<Name>;
+  /** needed for visualizations */
+  groupBy(columns: Array<string | ColumnCursor<string>>): Array<DataFrame<Name>>
 }
 
-export interface IteratableFrame<Name extends string> extends WithCursor<Name> {
+export interface IteratableFrame<Name extends string> extends WithColumnMethods<Name> {
   /** needed for stats module */
   readonly schema: Schema<Name>;
   /** needed for visualisations */
   mapRows<Result>(callback: (row: RawRow, index: number) => Result): Result[];
+  /** needed for visualizations */
+  groupBy(columns: Array<string | ColumnCursor<string>>): Array<DataFrame<Name>>
 }
 
 export interface PivotProps<Column extends string, Row extends string> {

--- a/packages/frame/src/types.ts
+++ b/packages/frame/src/types.ts
@@ -1,4 +1,4 @@
-import { DataFrame } from "./DataFrame";
+import { FragmentFrame } from "./FragmentFrame";
 
 /**
  * Can represent array of arrays or list of tuples or tuple of lists
@@ -18,19 +18,17 @@ export type Schema<Name extends string> = Array<{ name: Name; type?: any }>;
  */
 export type RawRow = any[];
 
-export interface WithColumnMethods<Name extends string> {
+export interface WithCursor<Name extends string> {
   getCursor(column: Name): ColumnCursor<Name>;
-  /** needed for visualizations */
-  groupBy(columns: Array<string | ColumnCursor<string>>): Array<DataFrame<Name>>
 }
 
-export interface IteratableFrame<Name extends string> extends WithColumnMethods<Name> {
+export interface IteratableFrame<Name extends string> extends WithCursor<Name> {
   /** needed for stats module */
   readonly schema: Schema<Name>;
   /** needed for visualisations */
   mapRows<Result>(callback: (row: RawRow, index: number) => Result): Result[];
   /** needed for visualizations */
-  groupBy(columns: Array<string | ColumnCursor<string>>): Array<DataFrame<Name>>
+  groupBy(columns: Array<string | ColumnCursor<string>>): Array<FragmentFrame<Name>>
 }
 
 export interface PivotProps<Column extends string, Row extends string> {

--- a/packages/frame/src/types.ts
+++ b/packages/frame/src/types.ts
@@ -1,5 +1,3 @@
-import { FragmentFrame } from "./FragmentFrame";
-
 /**
  * Can represent array of arrays or list of tuples or tuple of lists
  */

--- a/packages/frame/src/types.ts
+++ b/packages/frame/src/types.ts
@@ -28,7 +28,7 @@ export interface IteratableFrame<Name extends string> extends WithCursor<Name> {
   /** needed for visualisations */
   mapRows<Result>(callback: (row: RawRow, index: number) => Result): Result[];
   /** needed for visualizations */
-  groupBy(columns: Array<string | ColumnCursor<string>>): Array<FragmentFrame<Name>>
+  groupBy(columns: Array<string | ColumnCursor<string>>): Array<IteratableFrame<Name>>
 }
 
 export interface PivotProps<Column extends string, Row extends string> {

--- a/packages/frame/src/utils.ts
+++ b/packages/frame/src/utils.ts
@@ -1,0 +1,4 @@
+import { ColumnCursor } from "./types";
+
+export const isCursor = (x: any): x is ColumnCursor<any> =>
+  !!x.index && x instanceof Function;


### PR DESCRIPTION
Added `groupBy` method to `DataFrame`, `PivotFrame` and `FragmentFrame` to enable the user to split an existing frame into an array of data frames based on the unique values or combination of values of one or several dimensions. 

This is needed for splitting non-stacked renderers (e.g. line charts) up into multiple series.