### PR TITLE
Improve style prop types for charts.

### DIFF
--- a/packages/visualizations-stories/src/vizualisations/1-bar-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/1-bar-chart.stories.tsx
@@ -64,6 +64,12 @@ interface BarChartProps<Name extends string> {
   metric: Name;
   metricDirection: AxialChartProps<string>["metricDirection"];
 }
+const colors = {
+  "Germany": "#1499CE",
+  "UK": "#7C246F",
+  "USA": "#EAD63F",
+  "Canada": "#343972",
+};
 
 /**
  * Example of how you can compose more complex charts out of 'atoms'
@@ -87,6 +93,7 @@ const BarChart = <Name extends string>({
     column: data.getCursor(metric),
     range: metricDirection === "horizontal" ? [0, width] : [height, 0],
   });
+  const colorCursor = data.getCursor("Customer.Country" as Name);
 
   return (
     <Chart width={width} height={height} margin={margin} style={{ background: "#fff" }}>
@@ -97,7 +104,7 @@ const BarChart = <Name extends string>({
         metric={data.getCursor(metric)}
         categoricalScale={categoricalScale}
         metricScale={metricScale}
-        style={{ fill: "#1f78b4" }}
+        style={row => ({ fill: colors[colorCursor(row) as "Germany" | "UK" | "USA" | "Canada"] })}
       />
       <Axis scale={categoricalScale} position={metricDirection === "horizontal" ? "left" : "bottom"} />
       <Axis scale={metricScale} position={metricDirection === "horizontal" ? "bottom" : "left"} />

--- a/packages/visualizations/src/Area.tsx
+++ b/packages/visualizations/src/Area.tsx
@@ -1,10 +1,9 @@
 import { area } from "d3-shape";
 import React from "react";
 import { useChartTransform } from "./Chart";
-import { AxialChart } from "./types";
-import { isFunction } from "./utils";
+import { LinearAxialChart } from "./types";
 
-export const Area: AxialChart<string> = React.memo(props => {
+export const Area: LinearAxialChart<string> = React.memo(props => {
   const defaultTransform = useChartTransform();
 
   const { metricDirection, data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
@@ -30,7 +29,7 @@ export const Area: AxialChart<string> = React.memo(props => {
 
   return (
     <g transform={transform || defaultTransform}>
-      <path d={path} style={isFunction(style) ? style(0) : style} />
+      <path d={path} style={style} />
     </g>
   );
 });

--- a/packages/visualizations/src/Bars.tsx
+++ b/packages/visualizations/src/Bars.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { useChartTransform } from "./Chart";
-import { AxialChart } from "./types";
+import { DiscreteAxialChart } from "./types";
 import { isFunction } from "./utils";
 
-export const Bars: AxialChart<string> = props => {
+export const Bars: DiscreteAxialChart<string> = props => {
   const defaultTransform = useChartTransform();
 
   if (props.metricDirection === "vertical") {
@@ -18,7 +18,7 @@ export const Bars: AxialChart<string> = props => {
             y={metricScale(metric(row))}
             width={categoricalScale.bandwidth()}
             height={height - metricScale(metric(row))}
-            style={isFunction(style) ? style(i) : style}
+            style={isFunction(style) ? style(row, i) : style}
             key={i}
           />
         ))}
@@ -34,7 +34,7 @@ export const Bars: AxialChart<string> = props => {
             x={0}
             height={categoricalScale.bandwidth()}
             width={metricScale(metric(row))}
-            style={isFunction(style) ? style(i) : style}
+            style={isFunction(style) ? style(row, i) : style}
             key={i}
           />
         ))}

--- a/packages/visualizations/src/Line.tsx
+++ b/packages/visualizations/src/Line.tsx
@@ -1,10 +1,9 @@
 import { line } from "d3-shape";
 import React from "react";
 import { useChartTransform } from "./Chart";
-import { AxialChart } from "./types";
-import { isFunction } from "./utils";
+import { LinearAxialChart } from "./types";
 
-export const Line: AxialChart<string> = React.memo(props => {
+export const Line: LinearAxialChart<string> = React.memo(props => {
   const defaultTransform = useChartTransform();
 
   const { metricDirection, data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
@@ -15,10 +14,9 @@ export const Line: AxialChart<string> = React.memo(props => {
   const pathData = data.mapRows(row => {
     const categoricalValue = categoricalTickWidth / 2 + (categoricalScale(categorical(row)) as number);
     const metricValue = metricScale(metric(row));
-    return (metricDirection === "vertical" ? [categoricalValue, metricValue] : [metricValue, categoricalValue]) as [
-      number,
-      number
-    ];
+    return (metricDirection === "vertical"
+      ? [categoricalValue, metricValue]
+      : [metricValue, categoricalValue]) as [number, number];
   });
 
   const path =
@@ -32,7 +30,7 @@ export const Line: AxialChart<string> = React.memo(props => {
         d={path}
         style={{
           fill: "none",
-          ...(isFunction(style) ? style(0) : style),
+          ...style
         }}
       />
     </g>

--- a/packages/visualizations/src/types.ts
+++ b/packages/visualizations/src/types.ts
@@ -1,7 +1,7 @@
 import { ColumnCursor, IteratableFrame } from "@operational/frame";
 import { ScaleBand, ScaleLinear } from "d3-scale";
 
-export interface AxialChartProps<Name extends string> {
+export interface BaseAxialChartProps<Name extends string> {
   metricDirection: "horizontal" | "vertical";
   data: IteratableFrame<Name>;
   metric: ColumnCursor<Name>;
@@ -9,7 +9,20 @@ export interface AxialChartProps<Name extends string> {
   metricScale: ScaleLinear<any, any>;
   categoricalScale: ScaleBand<string>;
   transform?: React.SVGAttributes<SVGRectElement>["transform"];
-  style?: React.SVGAttributes<SVGGElement>["style"] | ((i: number) => React.SVGAttributes<SVGGElement>["style"]);
 }
+
+export type DiscreteAxialChartProps<Name extends string> = BaseAxialChartProps<Name> & {
+  style?: React.SVGAttributes<SVGGElement>["style"] | ((d: any[], i?: number) => React.SVGAttributes<SVGGElement>["style"]);
+}
+
+export type LinearAxialChartProps<Name extends string> = BaseAxialChartProps<Name> & {
+  style?: React.SVGAttributes<SVGGElement>["style"];
+}
+
+export type AxialChartProps<Name extends string> = DiscreteAxialChartProps<Name> | LinearAxialChartProps<Name>
+
+export type DiscreteAxialChart<Name extends string> = (props: DiscreteAxialChartProps<Name>) => React.ReactElement | null;
+
+export type LinearAxialChart<Name extends string> = (props: LinearAxialChartProps<Name>) => React.ReactElement | null;
 
 export type AxialChart<Name extends string> = (props: AxialChartProps<Name>) => React.ReactElement | null;

--- a/packages/visualizations/src/types.ts
+++ b/packages/visualizations/src/types.ts
@@ -1,4 +1,4 @@
-import { ColumnCursor, IteratableFrame } from "@operational/frame";
+import { ColumnCursor, IteratableFrame, RawRow } from "@operational/frame";
 import { ScaleBand, ScaleLinear } from "d3-scale";
 
 export interface BaseAxialChartProps<Name extends string> {
@@ -12,7 +12,7 @@ export interface BaseAxialChartProps<Name extends string> {
 }
 
 export type DiscreteAxialChartProps<Name extends string> = BaseAxialChartProps<Name> & {
-  style?: React.SVGAttributes<SVGGElement>["style"] | ((d: any[], i?: number) => React.SVGAttributes<SVGGElement>["style"]);
+  style?: React.SVGAttributes<SVGGElement>["style"] | ((row: RawRow, i: number) => React.SVGAttributes<SVGGElement>["style"]);
 }
 
 export type LinearAxialChartProps<Name extends string> = BaseAxialChartProps<Name> & {


### PR DESCRIPTION
Previously, line and area charts were allowed to have a function passed in as the style prop, even though each line or area rendered must have static styling.

Conversely, bars could only be coloured by their index, and not by any other property - now the style prop can be a function that takes both row and row index as arguments. 
 