### PR TITLE
Expose uniqueValues method on IterableFrames.

### DIFF
--- a/packages/frame/package.json
+++ b/packages/frame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@operational/frame",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Contiamo DataFrame.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/frame/src/DataFrame.ts
+++ b/packages/frame/src/DataFrame.ts
@@ -62,6 +62,11 @@ export class DataFrame<Name extends string = string> implements IterableFrame<Na
     })
   }
 
+  public uniqueValues(columns: Array<Name | ColumnCursor<Name>>): string[][] {
+    const columnCursors = columns.map(c => isCursor(c) ? c : this.getCursor(c));
+    return uniqueValueCombinations(this, columnCursors);
+  }
+
   public mapRows<A>(callback: (row: RawRow[], index: number) => A) {
     return this.data.map(callback);
   }

--- a/packages/frame/src/FragmentFrame.ts
+++ b/packages/frame/src/FragmentFrame.ts
@@ -47,6 +47,11 @@ export class FragmentFrame<Name extends string = string> implements IterableFram
     })
   }
 
+  public uniqueValues(columns: Array<Name | ColumnCursor<Name>>): string[][] {
+    const columnCursors = columns.map(c =>isCursor(c) ? c : this.getCursor(c));
+    return uniqueValueCombinations(this, columnCursors);
+  }
+
   public mapRows<A>(callback: (row: RawRow, index: number) => A) {
     return this.index.map((i, j) => callback(this.data[i], j));
   }

--- a/packages/frame/src/types.ts
+++ b/packages/frame/src/types.ts
@@ -26,7 +26,9 @@ export interface IterableFrame<Name extends string> extends WithCursor<Name> {
   /** needed for visualisations */
   mapRows<Result>(callback: (row: RawRow, index: number) => Result): Result[];
   /** needed for visualizations */
-  groupBy(columns: Array<string | ColumnCursor<string>>): Array<IterableFrame<Name>>
+  groupBy(columns: Array<string | ColumnCursor<string>>): Array<IterableFrame<Name>>;
+  /** needed for visualizations */
+  uniqueValues(columns: Array<Name | ColumnCursor<Name>>): string[][];
 }
 
 export interface PivotProps<Column extends string, Row extends string> {


### PR DESCRIPTION
Add and expose a `uniqueValues` method on all `IterableFrame`s that returns an array of the unique combinations of values of any specified columns. 

Required for assigning colours/styles to visualizations. 