### PR TITLE
Enable conditional cell styling.

### DIFF
--- a/packages/frame/package.json
+++ b/packages/frame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@operational/frame",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Contiamo DataFrame.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/frame/src/DataFrame.ts
+++ b/packages/frame/src/DataFrame.ts
@@ -28,6 +28,10 @@ export class DataFrame<Name extends string = string> implements IterableFrame<Na
     return this.data[rowIndex][columnIndex];
   }
 
+  public row(rowIndex: number) {
+    return this.data[rowIndex];
+  }
+
   public getCursor(column: Name): ColumnCursor<Name> {
     if (!this.cursorCache.has(column)) {
       const index = this.schema.findIndex(x => x.name === column);

--- a/packages/frame/src/FragmentFrame.ts
+++ b/packages/frame/src/FragmentFrame.ts
@@ -56,6 +56,10 @@ export class FragmentFrame<Name extends string = string> implements IterableFram
     return this.index.map((i, j) => callback(this.data[i], j));
   }
 
+  public row(rowIndex: number) {
+    return this.data[rowIndex];
+  }
+
   // we need this function for table display
   public peak(column: Name | ColumnCursor<Name>) {
     const columnIndex = isColumnCursor(column) ? column.index : this.schema.findIndex(x => x.name === column);

--- a/packages/frame/src/FragmentFrame.ts
+++ b/packages/frame/src/FragmentFrame.ts
@@ -57,7 +57,7 @@ export class FragmentFrame<Name extends string = string> implements IterableFram
   }
 
   public row(rowIndex: number) {
-    return this.data[rowIndex];
+    return this.data[this.index[rowIndex]];
   }
 
   // we need this function for table display

--- a/packages/frame/src/types.ts
+++ b/packages/frame/src/types.ts
@@ -29,6 +29,8 @@ export interface IterableFrame<Name extends string> extends WithCursor<Name> {
   groupBy(columns: Array<string | ColumnCursor<string>>): Array<IterableFrame<Name>>;
   /** needed for visualizations */
   uniqueValues(columns: Array<Name | ColumnCursor<Name>>): string[][];
+  /** needed for visualizations */
+  row(rowIndex: number): RawRow;
 }
 
 export interface PivotProps<Column extends string, Row extends string> {

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@operational/grid",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Contiamo visualization library.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/grid/src/PivotGrid.tsx
+++ b/packages/grid/src/PivotGrid.tsx
@@ -113,7 +113,8 @@ interface Axes<Name extends string> {
 }
 
 interface PivotGridStyle {
-  cell?: React.CSSProperties | ((rowIndex: number, columnIndex: number) => React.CSSProperties);
+  // Static cell styles
+  cell?: React.CSSProperties;
   header?: React.CSSProperties;
   dimension?: React.CSSProperties;
   border?: string;
@@ -239,7 +240,7 @@ export const PivotGrid = React.memo(<Name extends string = string>(props: Props<
           break;
         case "Cell":
           border = {
-            ...cellStyle(cellCoordinates.row, cellCoordinates.column),
+            ...cellStyle,
             ...border,
           };
 

--- a/packages/grid/src/PivotGrid.tsx
+++ b/packages/grid/src/PivotGrid.tsx
@@ -23,6 +23,7 @@ import {
   WidthAccessor,
   HeightAccessor,
 } from "./types";
+import { isFunction } from "./utils";
 
 // Optimisation for hooks, because {} !== {}
 const emptyObject = Object.freeze({});
@@ -112,7 +113,7 @@ interface Axes<Name extends string> {
 }
 
 interface PivotGridStyle {
-  cell?: React.CSSProperties;
+  cell?: React.CSSProperties | ((rowIndex: number, columnIndex: number) => React.CSSProperties);
   header?: React.CSSProperties;
   dimension?: React.CSSProperties;
   border?: string;
@@ -155,7 +156,7 @@ export const PivotGrid = React.memo(<Name extends string = string>(props: Props<
   );
   const styleProp = props.style || (emptyObject as PivotGridStyle);
   const borderStyle = styleProp.border || defaultBorderStyle;
-  const cellStyle = styleProp.cell || emptyObject;
+  const cellStyle = isFunction(styleProp.cell) ? styleProp.cell : () => (styleProp.cell || emptyObject);
   const dimensionStyle = styleProp.dimension || defaultDimensionStyle;
   const headerStyle = styleProp.header || defaultHeaderStyle;
   const backgroundStyle = styleProp.background || defaultBackground;
@@ -238,7 +239,7 @@ export const PivotGrid = React.memo(<Name extends string = string>(props: Props<
           break;
         case "Cell":
           border = {
-            ...cellStyle,
+            ...cellStyle(cellCoordinates.row, cellCoordinates.column),
             ...border,
           };
 

--- a/packages/grid/src/PivotGrid.tsx
+++ b/packages/grid/src/PivotGrid.tsx
@@ -23,7 +23,6 @@ import {
   WidthAccessor,
   HeightAccessor,
 } from "./types";
-import { isFunction } from "./utils";
 
 // Optimisation for hooks, because {} !== {}
 const emptyObject = Object.freeze({});
@@ -157,7 +156,7 @@ export const PivotGrid = React.memo(<Name extends string = string>(props: Props<
   );
   const styleProp = props.style || (emptyObject as PivotGridStyle);
   const borderStyle = styleProp.border || defaultBorderStyle;
-  const cellStyle = isFunction(styleProp.cell) ? styleProp.cell : () => (styleProp.cell || emptyObject);
+  const cellStyle = styleProp.cell;
   const dimensionStyle = styleProp.dimension || defaultDimensionStyle;
   const headerStyle = styleProp.header || defaultHeaderStyle;
   const backgroundStyle = styleProp.background || defaultBackground;

--- a/packages/grid/src/PivotGrid.tsx
+++ b/packages/grid/src/PivotGrid.tsx
@@ -40,17 +40,7 @@ const toString = (value: boolean | string) => {
   return value;
 };
 
-const defaultCell = <Name extends string = string>({
-  column,
-  row,
-  data,
-  measure,
-}: {
-  data: PivotFrame<Name>;
-  row: number;
-  column: number;
-  measure: Name;
-}) => {
+const defaultCell = ({ column, row, data, measure }: CellPropsWithMeasure<string>) => {
   const value = data.cell(row, column).peak(measure);
   return value === null ? null : <>{value}</>;
 };

--- a/packages/grid/src/TableGrid.tsx
+++ b/packages/grid/src/TableGrid.tsx
@@ -1,6 +1,7 @@
 import { DataFrame } from "@operational/frame";
 import React, { useMemo } from "react";
 import { GridChildComponentProps, VariableSizeGrid } from "react-window";
+import { isFunction } from "./utils";
 
 type Diff<T, U> = T extends U ? never : T;
 type Defined<T> = Diff<T, undefined>;
@@ -32,7 +33,7 @@ interface Props<Name extends string = string> {
   height: number;
   data: DataFrame<Name>;
   style?: {
-    cell?: React.CSSProperties;
+    cell?: React.CSSProperties | ((rowIndex: number, columnIndex: number) => React.CSSProperties);
     header?: React.CSSProperties;
     dimension?: React.CSSProperties;
     border?: string;
@@ -57,7 +58,7 @@ export function TableGrid<Name extends string = string>(props: Props<Name>) {
 
   const styleProp = props.style || (emptyObject as Defined<Props<Name>["style"]>);
   const borderStyle = styleProp.border || defaultBorderStyle;
-  const cellStyle = styleProp.cell || emptyObject;
+  const cellStyle = isFunction(styleProp.cell) ? styleProp.cell : () => (styleProp.cell || emptyObject);
   const backgroundStyle = styleProp.background || defaultBackground;
   const headerStyle = styleProp.header || defaultHeaderStyle;
 
@@ -78,7 +79,7 @@ export function TableGrid<Name extends string = string>(props: Props<Name>) {
         const value = data.schema[columnIndex].name;
         item = header({ value });
       } else {
-        border = { ...cellStyle, ...border };
+        border = { ...border, ...cellStyle(rowIndex - 1, columnIndex) };
         item = `${data.cell(rowIndex - 1, columnIndex)}`;
       }
 

--- a/packages/grid/src/utils.ts
+++ b/packages/grid/src/utils.ts
@@ -1,0 +1,1 @@
+export const isFunction = (x: any): x is Function => x instanceof Function;

--- a/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
@@ -1,4 +1,4 @@
-import { DataFrame, uniqueValues } from "@operational/frame";
+import { DataFrame, uniqueValues, PivotFrame } from "@operational/frame";
 import { PivotGrid, RowProps, CellPropsWithMeasure } from "@operational/grid";
 import { Axis, Bars, useScaleBand, useScaleLinear } from "@operational/visualizations";
 import { storiesOf } from "@storybook/react";
@@ -418,6 +418,36 @@ storiesOf("@operational/grid/1. Pivot table", module)
       rows: ["Customer.Continent", "Customer.Country", "Customer.City"],
       columns: ["Customer.AgeGroup", "Customer.Gender"],
     });
+
+    const colorCell = <Name extends string = string>({
+      column,
+      row,
+      data,
+      measure,
+    }: {
+      data: PivotFrame<Name>;
+      row: number;
+      column: number;
+      measure: Name;
+    }) => {
+      const value = data.cell(row, column).peak(measure);
+
+      const countryCursor = pivotedFrame.getCursor("Customer.Country");
+      const genderCursor = pivotedFrame.getCursor("Customer.Gender");
+
+      const rawRow = data.cell(row, column).row(0);
+      const country = countryCursor(rawRow);
+      const gender = genderCursor(rawRow);
+
+      return <div style={{
+        padding: "10px",
+        textAlign: "right",
+        background: country === "UK"
+          ? "#f5b2b2"
+          : gender === "Male" ? "#eee" : "#fff"
+      }}>{value === null ? null : <>{value}</>}</div>
+    };
+
     return (
       <AutoSizer style={{ minHeight: "500px", height: "100%" }}>
         {({ width, height }) => (
@@ -426,19 +456,8 @@ storiesOf("@operational/grid/1. Pivot table", module)
             height={height}
             data={pivotedFrame}
             measures={["sales", "revenue"]}
+            cell={colorCell}
             style={{
-              cell: (rowIndex, columnIndex) => {
-                const rowHeaders = pivotedFrame.rowHeaders();
-                const columnHeaders = pivotedFrame.columnHeaders();
-                const countryCursor = pivotedFrame.getCursor("Customer.Country");
-                const genderIndex = pivotedFrame.getCursor("Customer.Gender").index - rowHeaders[0].length;
-                return {
-                  padding: "10px",
-                  textAlign: "right",
-                  background: countryCursor(rowHeaders[rowIndex]) === "UK"
-                    ? "#f5b2b2"
-                    : columnHeaders[columnIndex][genderIndex] === "Male" ? "#eee" : "#fff"
-              }},
               background: "rgb(246, 246, 246)",
               // background: "linear-gradient(to right, orange , yellow, green, cyan, blue, violet)",
               header: {

--- a/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
@@ -1,4 +1,4 @@
-import { DataFrame, uniqueValues, PivotFrame } from "@operational/frame";
+import { DataFrame, uniqueValues } from "@operational/frame";
 import { PivotGrid, RowProps, CellPropsWithMeasure } from "@operational/grid";
 import { Axis, Bars, useScaleBand, useScaleLinear } from "@operational/visualizations";
 import { storiesOf } from "@storybook/react";
@@ -419,17 +419,7 @@ storiesOf("@operational/grid/1. Pivot table", module)
       columns: ["Customer.AgeGroup", "Customer.Gender"],
     });
 
-    const colorCell = <Name extends string = string>({
-      column,
-      row,
-      data,
-      measure,
-    }: {
-      data: PivotFrame<Name>;
-      row: number;
-      column: number;
-      measure: Name;
-    }) => {
+    const colorCell = ({ column, row, data, measure }: CellPropsWithMeasure<string>) => {
       const value = data.cell(row, column).peak(measure);
 
       const countryCursor = pivotedFrame.getCursor("Customer.Country");

--- a/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/1-pivot-grid.stories.tsx
@@ -412,4 +412,46 @@ storiesOf("@operational/grid/1. Pivot table", module)
         )}
       </AutoSizer>
     );
+  })
+  .add("with cell colors", () => {
+    const pivotedFrame = frame.pivot({
+      rows: ["Customer.Continent", "Customer.Country", "Customer.City"],
+      columns: ["Customer.AgeGroup", "Customer.Gender"],
+    });
+    return (
+      <AutoSizer style={{ minHeight: "500px", height: "100%" }}>
+        {({ width, height }) => (
+          <PivotGrid
+            width={width}
+            height={height}
+            data={pivotedFrame}
+            measures={["sales", "revenue"]}
+            style={{
+              cell: (rowIndex, columnIndex) => {
+                const rowHeaders = pivotedFrame.rowHeaders();
+                const columnHeaders = pivotedFrame.columnHeaders();
+                const countryCursor = pivotedFrame.getCursor("Customer.Country");
+                const genderIndex = pivotedFrame.getCursor("Customer.Gender").index - rowHeaders[0].length;
+                return {
+                  padding: "10px",
+                  textAlign: "right",
+                  background: countryCursor(rowHeaders[rowIndex]) === "UK"
+                    ? "#f5b2b2"
+                    : columnHeaders[columnIndex][genderIndex] === "Male" ? "#eee" : "#fff"
+              }},
+              background: "rgb(246, 246, 246)",
+              // background: "linear-gradient(to right, orange , yellow, green, cyan, blue, violet)",
+              header: {
+                padding: "10px",
+                textOverflow: "ellipsis",
+                overflow: "hidden",
+                whiteSpace: "nowrap",
+              },
+            }}
+            measuresPlacement="column"
+            dimensionLabels="top"
+          />
+        )}
+      </AutoSizer>
+    );
   });

--- a/packages/visualizations-stories/src/grid/2-table-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/2-table-grid.stories.tsx
@@ -95,6 +95,7 @@ storiesOf("@operational/grid/2. Table", module).add("basic", () => {
   );
 })
 .add("with colors", () => {
+  const countryCursor = frame.getCursor("Customer.Country")
   return (
     <AutoSizer style={{ minHeight: "500px", height: "100%" }}>
       {({ width, height }) => (
@@ -103,7 +104,10 @@ storiesOf("@operational/grid/2. Table", module).add("basic", () => {
           height={height}
           data={frame}
           style={{
-            cell: (rowIndex, columnIndex) => ({ padding: "10px", background: columnIndex > 0 ? colors[frame.row(rowIndex)[1] as "Germany" | "UK" | "USA" | "Canada"] : "#fff" }),
+            cell: (rowIndex, columnIndex) => ({
+              padding: "10px",
+              background: columnIndex > 0 ? colors[countryCursor(frame.row(rowIndex)) as "Germany" | "UK" | "USA" | "Canada"] : "#fff",
+            }),
             background: "#ddd"
           }}
         />

--- a/packages/visualizations-stories/src/grid/2-table-grid.stories.tsx
+++ b/packages/visualizations-stories/src/grid/2-table-grid.stories.tsx
@@ -73,6 +73,13 @@ const rawData = {
 
 const frame = new DataFrame(rawData.columns, rawData.rows);
 
+const colors = {
+  "Germany": "#f5b2b2",
+  "UK": "#7ea2f5",
+  "USA": "#f5cb7e",
+  "Canada": "#eee",
+}
+
 storiesOf("@operational/grid/2. Table", module).add("basic", () => {
   return (
     <AutoSizer style={{ minHeight: "500px", height: "100%" }}>
@@ -81,8 +88,23 @@ storiesOf("@operational/grid/2. Table", module).add("basic", () => {
           width={width}
           height={height}
           data={frame}
+          style={{ cell: { padding: "10px" } }}
+        />
+      )}
+    </AutoSizer>
+  );
+})
+.add("with colors", () => {
+  return (
+    <AutoSizer style={{ minHeight: "500px", height: "100%" }}>
+      {({ width, height }) => (
+        <TableGrid
+          width={width}
+          height={height}
+          data={frame}
           style={{
-            cell: { padding: "10px" },
+            cell: (rowIndex, columnIndex) => ({ padding: "10px", background: columnIndex > 0 ? colors[frame.row(rowIndex)[1] as "Germany" | "UK" | "USA" | "Canada"] : "#fff" }),
+            background: "#ddd"
           }}
         />
       )}


### PR DESCRIPTION
Optionally pass row and column indices to cell style prop to enable conditional row/column/cell formatting for tables and pivot grids.

![image](https://user-images.githubusercontent.com/14272822/61855476-6d2b0300-aec0-11e9-8f3a-65ffbb9fe366.png)

![image](https://user-images.githubusercontent.com/14272822/61855458-643a3180-aec0-11e9-9829-3efcb9b9dc2c.png)
