### PR TITLE
Simplest scatter plot

### DIFF
--- a/packages/visualizations-stories/src/vizualisations/5-scatter-plot.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/5-scatter-plot.stories.tsx
@@ -111,15 +111,13 @@ const ScatterPlot = <Name extends string>({
   const categoricalCursor = data.getCursor(categorical);
   const metricCursor = data.getCursor(metric);
 
-  const frame = data.groupBy([categoricalCursor]);
-
   const categoricalScale = useScaleBand({
     frame: data,
     column: categoricalCursor,
     range: metricDirection === "horizontal" ? [0, height] : [0, width],
   });
   const metricScale = useScaleLinear({
-    frame,
+    frame: data,
     column: metricCursor,
     range: metricDirection === "horizontal" ? [0, width] : [height, 0],
   });
@@ -129,17 +127,15 @@ const ScatterPlot = <Name extends string>({
 
   return (
     <Chart width={width} height={height} margin={margin} style={{ background: "#fff" }}>
-      {frame.map(grouped => (
-        <Dots
-          metricDirection={metricDirection}
-          data={grouped}
-          categorical={categoricalCursor}
-          metric={metricCursor}
-          categoricalScale={categoricalScale}
-          metricScale={metricScale}
-          style={row => ({ fill: colorScale(row) })}
-        />
-      ))}
+      <Dots
+        metricDirection={metricDirection}
+        data={data}
+        categorical={categoricalCursor}
+        metric={metricCursor}
+        categoricalScale={categoricalScale}
+        metricScale={metricScale}
+        style={row => ({ fill: colorScale(row) })}
+      />
       <Axis scale={categoricalScale} position={metricDirection === "horizontal" ? "left" : "bottom"} />
       <Axis scale={metricScale} position={metricDirection === "horizontal" ? "bottom" : "left"} />
     </Chart>
@@ -171,38 +167,6 @@ storiesOf("@operational/visualizations/5. Scatter plot", module)
       <ScatterPlot
         metric="sales"
         categorical="Customer.City"
-        colorBy={["Customer.City"]}
-        width={300}
-        height={300}
-        margin={magicMargin}
-        data={frame}
-        metricDirection="vertical"
-      />
-    );
-  })
-  .add("stacked horizontal", () => {
-    // number of pixels picked manually to make sure that YAxis fits on the screen
-    const magicMargin = 60;
-    return (
-      <ScatterPlot
-        metric="sales"
-        categorical="Customer.Country"
-        colorBy={["Customer.Country", "Customer.City"]}
-        width={300}
-        height={300}
-        margin={magicMargin}
-        data={frame}
-        metricDirection="horizontal"
-      />
-    );
-  })
-  .add("stacked vertical", () => {
-    // number of pixels picked manually to make sure that YAxis fits on the screen
-    const magicMargin = 60;
-    return (
-      <ScatterPlot
-        metric="sales"
-        categorical="Customer.Continent"
         colorBy={["Customer.City"]}
         width={300}
         height={300}

--- a/packages/visualizations-stories/src/vizualisations/5-scatter-plot.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/5-scatter-plot.stories.tsx
@@ -1,0 +1,214 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { DataFrame, IterableFrame, ColumnCursor, RowCursor } from "@operational/frame";
+import {
+  AxialChartProps,
+  Axis,
+  Dots,
+  Chart,
+  ChartProps,
+  useScaleBand,
+  useScaleLinear,
+} from "@operational/visualizations";
+
+const rawData = {
+  columns: [
+    {
+      name: "Customer.Continent" as "Customer.Continent",
+      type: "string",
+    },
+    {
+      name: "Customer.Country" as "Customer.Country",
+      type: "string",
+    },
+    {
+      name: "Customer.City" as "Customer.City",
+      type: "string",
+    },
+    {
+      name: "Customer.AgeGroup" as "Customer.AgeGroup",
+      type: "string",
+    },
+    {
+      name: "Customer.Gender" as "Customer.Gender",
+      type: "string",
+    },
+    {
+      name: "sales" as "sales",
+      type: "number",
+    },
+    {
+      name: "revenue" as "revenue",
+      type: "number",
+    },
+  ],
+  rows: [
+    ["Europe", "Germany", "Berlin", "<50", "Female", 101, 10.2],
+    ["Europe", "Germany", "Dresden", "<50", "Female", 201, 20.2],
+    ["Europe", "Germany", "Hamburg", "<50", "Female", 301, 30.2],
+    ["Europe", "UK", "London", "<50", "Female", 401, 40.2],
+    ["Europe", "UK", "Edinburgh", "<50", "Female", 501, 50.2],
+    ["North America", "USA", "New York", "<50", "Female", 801, 80.2],
+    ["North America", "Canada", "Toronto", "<50", "Female", 801, 80.2],
+  ],
+};
+
+const frame = new DataFrame(rawData.columns, rawData.rows);
+
+interface ScatterPlotProps<Name extends string> {
+  width: number;
+  height: number;
+  margin: ChartProps["margin"];
+  data: DataFrame<Name>;
+  categorical: Name;
+  metric: Name;
+  metricDirection: AxialChartProps<string>["metricDirection"];
+  colorBy?: Name[];
+}
+
+const colorPalette = [
+  "#1499CE",
+  "#7C246F",
+  "#EAD63F",
+  "#343972",
+  "#ED5B17",
+  "#009691",
+  "#1D6199",
+  "#D31F1F",
+  "#AD329C",
+  "#006865",
+];
+
+export const joinArrayAsString = (array: string[]) => {
+  return (array || []).join("/");
+};
+
+export const getColorScale = (frame: IterableFrame<string>, colorBy: Array<ColumnCursor<string>>) => {
+  if (colorBy.length === 0) {
+    return () => colorPalette[0];
+  }
+  const uniqueValues = frame.uniqueValues(colorBy).map(joinArrayAsString);
+  return (row: RowCursor) => {
+    const valuesString = joinArrayAsString(colorBy.map(cursor => cursor(row)));
+    const index = uniqueValues.indexOf(valuesString);
+    return colorPalette[index % colorPalette.length];
+  };
+};
+
+/**
+ * Example of how you can compose more complex charts out of 'atoms'
+ */
+const ScatterPlot = <Name extends string>({
+  width,
+  height,
+  margin,
+  data,
+  categorical,
+  metric,
+  metricDirection,
+  colorBy,
+}: ScatterPlotProps<Name>) => {
+  const categoricalCursor = data.getCursor(categorical);
+  const metricCursor = data.getCursor(metric);
+
+  const frame = data.groupBy([categoricalCursor]);
+
+  const categoricalScale = useScaleBand({
+    frame: data,
+    column: categoricalCursor,
+    range: metricDirection === "horizontal" ? [0, height] : [0, width],
+  });
+  const metricScale = useScaleLinear({
+    frame,
+    column: metricCursor,
+    range: metricDirection === "horizontal" ? [0, width] : [height, 0],
+  });
+
+  const colorByCursor = (colorBy || []).map(x => data.getCursor(x));
+  const colorScale = getColorScale(data, colorByCursor);
+
+  return (
+    <Chart width={width} height={height} margin={margin} style={{ background: "#fff" }}>
+      {frame.map(grouped => (
+        <Dots
+          metricDirection={metricDirection}
+          data={grouped}
+          categorical={categoricalCursor}
+          metric={metricCursor}
+          categoricalScale={categoricalScale}
+          metricScale={metricScale}
+          style={row => ({ fill: colorScale(row) })}
+        />
+      ))}
+      <Axis scale={categoricalScale} position={metricDirection === "horizontal" ? "left" : "bottom"} />
+      <Axis scale={metricScale} position={metricDirection === "horizontal" ? "bottom" : "left"} />
+    </Chart>
+  );
+};
+
+storiesOf("@operational/visualizations/5. Scatter plot", module)
+  .add("horizontal", () => {
+    // number of pixels picked manually to make sure that YAxis fits on the screen
+    const magicMargin = [5, 10, 20, 60] as ChartProps["margin"];
+
+    return (
+      <ScatterPlot
+        metric="sales"
+        categorical="Customer.City"
+        colorBy={["Customer.City"]}
+        width={300}
+        height={300}
+        margin={magicMargin}
+        data={frame}
+        metricDirection="horizontal"
+      />
+    );
+  })
+  .add("vertical", () => {
+    // number of pixels picked manually to make sure that YAxis fits on the screen
+    const magicMargin = 60;
+    return (
+      <ScatterPlot
+        metric="sales"
+        categorical="Customer.City"
+        colorBy={["Customer.City"]}
+        width={300}
+        height={300}
+        margin={magicMargin}
+        data={frame}
+        metricDirection="vertical"
+      />
+    );
+  })
+  .add("stacked horizontal", () => {
+    // number of pixels picked manually to make sure that YAxis fits on the screen
+    const magicMargin = 60;
+    return (
+      <ScatterPlot
+        metric="sales"
+        categorical="Customer.Country"
+        colorBy={["Customer.Country", "Customer.City"]}
+        width={300}
+        height={300}
+        margin={magicMargin}
+        data={frame}
+        metricDirection="horizontal"
+      />
+    );
+  })
+  .add("stacked vertical", () => {
+    // number of pixels picked manually to make sure that YAxis fits on the screen
+    const magicMargin = 60;
+    return (
+      <ScatterPlot
+        metric="sales"
+        categorical="Customer.Continent"
+        colorBy={["Customer.City"]}
+        width={300}
+        height={300}
+        margin={magicMargin}
+        data={frame}
+        metricDirection="vertical"
+      />
+    );
+  });

--- a/packages/visualizations/src/Bars.tsx
+++ b/packages/visualizations/src/Bars.tsx
@@ -5,9 +5,9 @@ import { isFunction } from "./utils";
 
 export const Bars: DiscreteAxialChart<string> = props => {
   const defaultTransform = useChartTransform();
+  const { data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
 
   if (props.metricDirection === "vertical") {
-    const { data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
     const height = metricScale(metricScale.domain()[0]);
     let accumulatedHeight = 0;
 
@@ -30,7 +30,6 @@ export const Bars: DiscreteAxialChart<string> = props => {
       </g>
     );
   } else {
-    const { data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
     let accumulatedWidth = 0;
 
     return (

--- a/packages/visualizations/src/Dots.tsx
+++ b/packages/visualizations/src/Dots.tsx
@@ -7,12 +7,12 @@ const radius = 3;
 
 export const Dots: DiscreteAxialChart<string> = props => {
   const defaultTransform = useChartTransform();
-  const { data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
+  const { data, transform, metric, categorical, metricScale, categoricalScale, metricDirection, style } = props;
 
   const bandWidth = categoricalScale.bandwidth();
 
   // this doesn't make much sense for ScatterPlot, but this is temprorary solution for compatibility
-  if (props.metricDirection === "vertical") {
+  if (metricDirection === "vertical") {
     return (
       <g transform={transform || defaultTransform}>
         {data.mapRows((row, i) => (

--- a/packages/visualizations/src/Dots.tsx
+++ b/packages/visualizations/src/Dots.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { useChartTransform } from "./Chart";
+import { DiscreteAxialChart } from "./types";
+import { isFunction } from "./utils";
+
+const radius = 3;
+
+export const Dots: DiscreteAxialChart<string> = props => {
+  const defaultTransform = useChartTransform();
+  const { data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
+
+  const bandWidth = categoricalScale.bandwidth();
+
+  // this doesn't make much sense for ScatterPlot, but this is temprorary solution for compatibility
+  if (props.metricDirection === "vertical") {
+    return (
+      <g transform={transform || defaultTransform}>
+        {data.mapRows((row, i) => (
+          <circle
+            cx={categoricalScale(categorical(row))! + bandWidth / 2}
+            cy={metricScale(metric(row))}
+            r={radius}
+            style={isFunction(style) ? style(row, i) : style}
+            key={i}
+          />
+        ))}
+      </g>
+    );
+  } else {
+    return (
+      <g transform={transform || defaultTransform}>
+        {data.mapRows((row, i) => (
+          <circle
+            cx={metricScale(metric(row))}
+            cy={categoricalScale(categorical(row))! + bandWidth / 2}
+            r={radius}
+            style={isFunction(style) ? style(row, i) : style}
+            key={i}
+          />
+        ))}
+      </g>
+    );
+  }
+};

--- a/packages/visualizations/src/index.ts
+++ b/packages/visualizations/src/index.ts
@@ -2,6 +2,7 @@ export { Axis } from "./Axis";
 export { Area } from "./Area";
 export { Bars } from "./Bars";
 export { Line } from "./Line";
+export { Dots } from "./Dots";
 export { Chart, ChartProps } from "./Chart";
 export { AxialChart, AxialChartProps } from "./types";
 export * from "./scale";


### PR DESCRIPTION
The most primitive implementation that mimics BarChart API for now. In reality it should support metric and categorical cases along all axes, as well we probably would want to use X and Y. But this is good as start, because it will be easy to integrate and later when we resolve https://github.com/contiamo/operational-visualizations/issues/73 we can think about how we want to change this one

<img width="374" alt="Screenshot 2019-08-05 at 15 09 52" src="https://user-images.githubusercontent.com/179534/62467042-24622c80-b793-11e9-8bb9-d6ad8f84a8e9.png">

<img width="379" alt="Screenshot 2019-08-05 at 15 10 00" src="https://user-images.githubusercontent.com/179534/62467043-24622c80-b793-11e9-8546-260f941acf14.png">
