### PR TITLE
Toggle labels through props.

### DIFF
--- a/docs/adr/00005-about-measure-labels.md
+++ b/docs/adr/00005-about-measure-labels.md
@@ -1,0 +1,16 @@
+The visualization library contains a `Labels` component, which can be used in the same way as all other axial chart renderers:
+
+```
+<Chart>
+  <Bars ... />
+  <Labels ... />
+</Chart>
+```
+
+However, the user can also display labels by passing a `displayLabels` flag. This solves multiple problems:
+
+- In the case of stacked bars or area charts, using the above API does not take stacking into account, so the labels will be in the wrong places.
+
+- The `Labels` component only works for axial charts, not for pie charts, so `PieChart` would have needed a flag anyway - this ensures consistency across all renderers.
+
+- For scatter plots, the labels are now automatically offset by the radius of the dots. Any other renderer-specific styling that may be required is now also easier.

--- a/docs/adr/00005-about-measure-labels.md
+++ b/docs/adr/00005-about-measure-labels.md
@@ -7,7 +7,7 @@ The visualization library contains a `Labels` component, which can be used in th
 </Chart>
 ```
 
-However, the user can also display labels by passing a `displayLabels` flag. This solves multiple problems:
+However, the user can also display labels by passing a `showLabels` flag. This solves multiple problems:
 
 - In the case of stacked bars or area charts, using the above API does not take stacking into account, so the labels will be in the wrong places.
 

--- a/packages/visualizations-stories/src/vizualisations/1-bar-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/1-bar-chart.stories.tsx
@@ -158,7 +158,7 @@ const BarChart = <Name extends string>({
 storiesOf("@operational/visualizations/1. Bar chart", module)
   .add("horizontal", () => {
     // number of pixels picked manually to make sure that YAxis fits on the screen
-    const magicMargin = [5, 10, 20, 60] as ChartProps["margin"];
+    const magicMargin = [5, 30, 20, 60] as ChartProps["margin"];
 
     return (
       <BarChart

--- a/packages/visualizations-stories/src/vizualisations/1-bar-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/1-bar-chart.stories.tsx
@@ -138,6 +138,7 @@ const BarChart = <Name extends string>({
             metric={metricCursor}
             categoricalScale={categoricalScale}
             metricScale={metricScale}
+            displayLabels={true}
             style={(row: RowCursor) => ({ fill: colorScale(row) })}
           />
         ))}

--- a/packages/visualizations-stories/src/vizualisations/1-bar-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/1-bar-chart.stories.tsx
@@ -138,7 +138,7 @@ const BarChart = <Name extends string>({
             metric={metricCursor}
             categoricalScale={categoricalScale}
             metricScale={metricScale}
-            displayLabels={true}
+            showLabels={true}
             style={(row: RowCursor) => ({ fill: colorScale(row) })}
           />
         ))}

--- a/packages/visualizations-stories/src/vizualisations/2-line-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/2-line-chart.stories.tsx
@@ -340,7 +340,7 @@ storiesOf("@operational/visualizations/2. Line chart", module)
   })
   .add("horizontal, multiple lines", () => {
     // number of pixels picked manually to make sure that YAxis fits on the screen
-    const magicMargin = [20, 10, 20, 60] as ChartProps["margin"];
+    const magicMargin = [20, 30, 20, 60] as ChartProps["margin"];
 
     return (
       <MultipleLines

--- a/packages/visualizations-stories/src/vizualisations/2-line-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/2-line-chart.stories.tsx
@@ -217,7 +217,7 @@ const LineChart = <Name extends string>({
           metric={metricCursor}
           categoricalScale={categoricalScale}
           metricScale={metricScale}
-          displayLabels={true}
+          showLabels={true}
           style={{ stroke: "#1f78b4" }}
         />
         <Axis scale={categoricalScale} position={metricDirection === "vertical" ? "bottom" : "left"} />
@@ -273,7 +273,7 @@ const MultipleLines = <Name extends string>({
             metric={metricCursor}
             categoricalScale={categoricalScale}
             metricScale={metricScale}
-            displayLabels={true}
+            showLabels={true}
             style={(row: RowCursor) => ({ stroke: colorScale(row), strokeWidth: 2 })}
           />
         ))}

--- a/packages/visualizations-stories/src/vizualisations/2-line-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/2-line-chart.stories.tsx
@@ -217,6 +217,7 @@ const LineChart = <Name extends string>({
           metric={metricCursor}
           categoricalScale={categoricalScale}
           metricScale={metricScale}
+          displayLabels={true}
           style={{ stroke: "#1f78b4" }}
         />
         <Axis scale={categoricalScale} position={metricDirection === "vertical" ? "bottom" : "left"} />
@@ -272,6 +273,7 @@ const MultipleLines = <Name extends string>({
             metric={metricCursor}
             categoricalScale={categoricalScale}
             metricScale={metricScale}
+            displayLabels={true}
             style={(row: RowCursor) => ({ stroke: colorScale(row), strokeWidth: 2 })}
           />
         ))}
@@ -289,7 +291,7 @@ const multiplesWithMissingDataFrame = new DataFrame(rawDataMultipleLinesMissingD
 storiesOf("@operational/visualizations/2. Line chart", module)
   .add("vertical", () => {
     // number of pixels picked manually to make sure that YAxis fits on the screen
-    const magicMargin = [5, 10, 20, 60] as ChartProps["margin"];
+    const magicMargin = [20, 10, 20, 60] as ChartProps["margin"];
 
     return (
       <LineChart
@@ -320,7 +322,7 @@ storiesOf("@operational/visualizations/2. Line chart", module)
   })
   .add("vertical, multiple lines", () => {
     // number of pixels picked manually to make sure that YAxis fits on the screen
-    const magicMargin = [5, 10, 20, 60] as ChartProps["margin"];
+    const magicMargin = [20, 10, 20, 60] as ChartProps["margin"];
 
     return (
       <MultipleLines
@@ -338,7 +340,7 @@ storiesOf("@operational/visualizations/2. Line chart", module)
   })
   .add("horizontal, multiple lines", () => {
     // number of pixels picked manually to make sure that YAxis fits on the screen
-    const magicMargin = [5, 10, 20, 60] as ChartProps["margin"];
+    const magicMargin = [20, 10, 20, 60] as ChartProps["margin"];
 
     return (
       <MultipleLines
@@ -356,7 +358,7 @@ storiesOf("@operational/visualizations/2. Line chart", module)
   })
   .add("vertical, all missing data", () => {
     // number of pixels picked manually to make sure that YAxis fits on the screen
-    const magicMargin = [5, 10, 20, 60] as ChartProps["margin"];
+    const magicMargin = [20, 10, 20, 60] as ChartProps["margin"];
 
     return (
       <MultipleLines
@@ -374,7 +376,7 @@ storiesOf("@operational/visualizations/2. Line chart", module)
   })
   .add("vertical, some missing data", () => {
     // number of pixels picked manually to make sure that YAxis fits on the screen
-    const magicMargin = [5, 10, 20, 60] as ChartProps["margin"];
+    const magicMargin = [20, 10, 20, 60] as ChartProps["margin"];
 
     return (
       <MultipleLines

--- a/packages/visualizations-stories/src/vizualisations/3-area-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/3-area-chart.stories.tsx
@@ -261,7 +261,7 @@ const AreaChart = <Name extends string>({
             categoricalScale={categoricalScale}
             metricScale={metricScale}
             displayLabels={true}
-            style={(row: RowCursor) => ({ fill: colorScale(row) })}          />
+            style={(row: RowCursor) => ({ fill: colorScale(row), stroke: colorScale(row) })}          />
         ))}
         <Axis
           scale={categoricalScale}

--- a/packages/visualizations-stories/src/vizualisations/3-area-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/3-area-chart.stories.tsx
@@ -260,7 +260,8 @@ const AreaChart = <Name extends string>({
             stack={stackByCursors}
             categoricalScale={categoricalScale}
             metricScale={metricScale}
-            style={(row: RowCursor) => ({ fill: colorScale(row), stroke: colorScale(row) })}          />
+            displayLabels={true}
+            style={(row: RowCursor) => ({ fill: colorScale(row) })}          />
         ))}
         <Axis
           scale={categoricalScale}
@@ -278,7 +279,7 @@ const AreaChart = <Name extends string>({
 storiesOf("@operational/visualizations/3. Area chart", module)
   .add("vertical", () => {
     // number of pixels picked manually to make sure that YAxis fits on the screen
-    const magicMargin = [5, 10, 20, 60] as ChartProps["margin"];
+    const magicMargin = [20, 10, 20, 60] as ChartProps["margin"];
 
     return (
       <AreaChart

--- a/packages/visualizations-stories/src/vizualisations/3-area-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/3-area-chart.stories.tsx
@@ -183,7 +183,7 @@ const rawDataStackedWithMissing = {
     ["Europe", "Germany", "Hamburg", "<50", "Female", 301, 30.2],
     ["Europe", "UK", "London", "<50", "Female", 401, 40.2],
     // ["Europe", "UK", "Edinburgh", "<50", "Female", 501, 50.2],
-    ["North America", "USA", "New York", "<50", "Female", 801, 80.2],
+    ["North America", "USA", "New York", "<50", "Female", 0, 80.2],
     ["North America", "Canada", "Toronto", "<50", "Female", 801, 80.2],
     ["Europe", "Germany", "Berlin", "<50", "Male", 101, 10.2],
     ["Europe", "Germany", "Dresden", "<50", "Male", undefined, 20.2],

--- a/packages/visualizations-stories/src/vizualisations/3-area-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/3-area-chart.stories.tsx
@@ -260,7 +260,7 @@ const AreaChart = <Name extends string>({
             stack={stackByCursors}
             categoricalScale={categoricalScale}
             metricScale={metricScale}
-            displayLabels={true}
+            showLabels={true}
             style={(row: RowCursor) => ({ fill: colorScale(row), stroke: colorScale(row) })}          />
         ))}
         <Axis

--- a/packages/visualizations-stories/src/vizualisations/5-scatter-plot.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/5-scatter-plot.stories.tsx
@@ -109,7 +109,7 @@ const ScatterPlot = <Name extends string>({
           metric={metricCursor}
           categoricalScale={categoricalScale}
           metricScale={metricScale}
-          displayLabels={true}
+          showLabels={true}
           style={(row: RowCursor) => ({ fill: colorScale(row) })}
         />
         <Axis scale={categoricalScale} position={metricDirection === "horizontal" ? "left" : "bottom"} />

--- a/packages/visualizations-stories/src/vizualisations/5-scatter-plot.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/5-scatter-plot.stories.tsx
@@ -109,6 +109,7 @@ const ScatterPlot = <Name extends string>({
           metric={metricCursor}
           categoricalScale={categoricalScale}
           metricScale={metricScale}
+          displayLabels={true}
           style={(row: RowCursor) => ({ fill: colorScale(row) })}
         />
         <Axis scale={categoricalScale} position={metricDirection === "horizontal" ? "left" : "bottom"} />

--- a/packages/visualizations-stories/src/vizualisations/6-pie-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/6-pie-chart.stories.tsx
@@ -80,6 +80,7 @@ const Pie = <Name extends string>({
           height={height}
           data={data}
           metric={metricCursor}
+          displayLabels={true}
           style={(row: RowCursor) => ({ fill: colorScale(row), stroke: "#fff" })}
         />
       ))}

--- a/packages/visualizations-stories/src/vizualisations/6-pie-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/6-pie-chart.stories.tsx
@@ -80,7 +80,7 @@ const Pie = <Name extends string>({
           height={height}
           data={data}
           metric={metricCursor}
-          displayLabels={true}
+          showLabels={true}
           style={(row: RowCursor) => ({ fill: colorScale(row), stroke: "#fff" })}
         />
       ))}

--- a/packages/visualizations/src/Area.tsx
+++ b/packages/visualizations/src/Area.tsx
@@ -16,7 +16,7 @@ export const Area: LinearAxialChart<string> = props => {
 
   const accumulatedCache: Record<string, number> = {};
 
-  const isDefined = (value: number | undefined) => value !==undefined;
+  const isDefined = (value: number | undefined) => value !== undefined;
 
   // The area path function takes an array of datum objects (here, called `d` for consistency with d3 naming conventions)
   // with the following properties:
@@ -68,7 +68,7 @@ export const Area: LinearAxialChart<string> = props => {
           return {
             c: categorical(row),
             m0: accumulatedValue,
-            m1: metricValue ? accumulatedValue + metricValue : undefined,
+            m1: isDefined(metricValue) ? accumulatedValue + metricValue : undefined,
           }
         }),
         firstRow: grouped.row(0)
@@ -99,25 +99,25 @@ export const Area: LinearAxialChart<string> = props => {
       {/* Render text labels. This is done at the end to ensure they are visible */}
       {showLabels && stackedData.map((stack, i) =>
         stack.data.map((d, j) =>
-          metricDirection === "vertical"
+           metricDirection === "vertical"
             ? <text
               key={`Label-${i}-${j}`}
               x={(categoricalScale(d.c) || 0) + categoricalTickWidth / 2}
               y={metricScale(d.m1)}
-              dy={"-0.35em"}
+              dy="-0.35em"
               style={verticalLabelStyle}
             >
-              {d.m1 - d.m0 || ""}
+              {isDefined(d.m1) && isDefined(d.m0) ? d.m1 - d.m0 : ""}
             </text>
             : <text
               key={`Label-${i}-${j}`}
               x={metricScale(d.m1)}
               y={(categoricalScale(d.c) || 0) + categoricalTickWidth / 2}
-              dx={4}
-              dy={"0.35em"}
+              dx="0.35em"
+              dy="0.35em"
               style={baseLabelStyle}
             >
-              {d.m1 - d.m0 || ""}
+              {isDefined(d.m1) && isDefined(d.m0) ? d.m1 - d.m0 : ""}
             </text>
         )
       )}

--- a/packages/visualizations/src/Area.tsx
+++ b/packages/visualizations/src/Area.tsx
@@ -3,11 +3,12 @@ import React from "react";
 import { useChartTransform } from "./Chart";
 import { LinearAxialChart } from "./types";
 import { isFunction } from "./utils";
+import { baseStyle as baseLabelStyle, verticalStyle as verticalLabelStyle } from "./Labels";
 
 export const Area: LinearAxialChart<string> = props => {
   const defaultTransform = useChartTransform();
 
-  const { metricDirection, data, transform, metric, categorical, metricScale, categoricalScale, stack, style } = props;
+  const { metricDirection, data, transform, metric, categorical, metricScale, categoricalScale, stack, displayLabels, style } = props;
 
   // The categorical scale must be a band scale for composability with bar charts.
   // Half of the tick width must be added to align with the ticks.
@@ -94,6 +95,37 @@ export const Area: LinearAxialChart<string> = props => {
           d={strokePath.defined(d => isDefined(d.m1))(stack.data) || ""}
           style={{ stroke: "#fff", fill: "none" }}
         />
+      )}
+      {/* Render text labels. This is done at the end to ensure they are visible */}
+      {displayLabels && stackedData.map((stack, i) =>
+        stack.data.map((d, j) =>
+          metricDirection === "vertical"
+            ? <text
+              key={`Label-${i}-${j}`}
+              x={(categoricalScale(d.c) || 0) + categoricalTickWidth / 2}
+              y={metricScale(d.m1)}
+              dy={"-0.35em"}
+              style={{
+                ...verticalLabelStyle,
+                // ...(isFunction(style) ? style(stack.firstRow, i) : style)
+              }}
+            >
+              {d.m1 - d.m0}
+            </text>
+            : <text
+              key={`Label-${i}-${j}`}
+              x={metricScale(d.m1)}
+              y={(categoricalScale(d.c) || 0) + categoricalTickWidth / 2}
+              dx={4}
+              dy={"0.35em"}
+              style={{
+                ...baseLabelStyle,
+                // ...(isFunction(style) ? style(stack.firstRow, i) : style)
+              }}
+            >
+              {d.m1 - d.m0}
+            </text>
+        )
       )}
     </g>
   );

--- a/packages/visualizations/src/Area.tsx
+++ b/packages/visualizations/src/Area.tsx
@@ -105,12 +105,9 @@ export const Area: LinearAxialChart<string> = props => {
               x={(categoricalScale(d.c) || 0) + categoricalTickWidth / 2}
               y={metricScale(d.m1)}
               dy={"-0.35em"}
-              style={{
-                ...verticalLabelStyle,
-                // ...(isFunction(style) ? style(stack.firstRow, i) : style)
-              }}
+              style={verticalLabelStyle}
             >
-              {d.m1 - d.m0}
+              {d.m1 - d.m0 || ""}
             </text>
             : <text
               key={`Label-${i}-${j}`}
@@ -118,12 +115,9 @@ export const Area: LinearAxialChart<string> = props => {
               y={(categoricalScale(d.c) || 0) + categoricalTickWidth / 2}
               dx={4}
               dy={"0.35em"}
-              style={{
-                ...baseLabelStyle,
-                // ...(isFunction(style) ? style(stack.firstRow, i) : style)
-              }}
+              style={baseLabelStyle}
             >
-              {d.m1 - d.m0}
+              {d.m1 - d.m0 || ""}
             </text>
         )
       )}

--- a/packages/visualizations/src/Area.tsx
+++ b/packages/visualizations/src/Area.tsx
@@ -8,7 +8,7 @@ import { baseStyle as baseLabelStyle, verticalStyle as verticalLabelStyle } from
 export const Area: LinearAxialChart<string> = props => {
   const defaultTransform = useChartTransform();
 
-  const { metricDirection, data, transform, metric, categorical, metricScale, categoricalScale, stack, displayLabels, style } = props;
+  const { metricDirection, data, transform, metric, categorical, metricScale, categoricalScale, stack, showLabels, style } = props;
 
   // The categorical scale must be a band scale for composability with bar charts.
   // Half of the tick width must be added to align with the ticks.
@@ -97,7 +97,7 @@ export const Area: LinearAxialChart<string> = props => {
         />
       )}
       {/* Render text labels. This is done at the end to ensure they are visible */}
-      {displayLabels && stackedData.map((stack, i) =>
+      {showLabels && stackedData.map((stack, i) =>
         stack.data.map((d, j) =>
           metricDirection === "vertical"
             ? <text

--- a/packages/visualizations/src/Bars.tsx
+++ b/packages/visualizations/src/Bars.tsx
@@ -33,7 +33,7 @@ export const Bars: DiscreteAxialChart<string> = props => {
             <text
               x={categoricalScale(categorical(row))! + bandWidth / 2}
               y={metricScale(metric(row)) - accumulatedHeight}
-              dy={"-0.35em"}
+              dy="-0.35em"
               style={verticalLabelStyle}
               key={`label-${i}`}
             >
@@ -69,8 +69,8 @@ export const Bars: DiscreteAxialChart<string> = props => {
             <text
               x={metricScale(metric(row)) + accumulatedWidth}
               y={categoricalScale(categorical(row))! + bandWidth / 2}
-              dx={4}
-              dy={"0.35em"}
+              dx="0.35em"
+              dy="0.35em"
               style={baseLabelStyle}
               key={`label-${i}`}
             >

--- a/packages/visualizations/src/Bars.tsx
+++ b/packages/visualizations/src/Bars.tsx
@@ -72,7 +72,7 @@ export const Bars: DiscreteAxialChart<string> = props => {
               dx={4}
               dy={"0.35em"}
               style={baseLabelStyle}
-              key={`label=${i}`}
+              key={`label-${i}`}
             >
               {metric(row)}
             </text>

--- a/packages/visualizations/src/Bars.tsx
+++ b/packages/visualizations/src/Bars.tsx
@@ -2,14 +2,19 @@ import React from "react";
 import { useChartTransform } from "./Chart";
 import { DiscreteAxialChart } from "./types";
 import { isFunction } from "./utils";
+import { baseStyle as baseLabelStyle, verticalStyle as verticalLabelStyle } from "./Labels";
 
 export const Bars: DiscreteAxialChart<string> = props => {
   const defaultTransform = useChartTransform();
-  const { data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
+  const { data, transform, metric, categorical, metricScale, categoricalScale, displayLabels, style } = props;
+  const bandWidth = categoricalScale.bandwidth();
 
   if (props.metricDirection === "vertical") {
     const height = metricScale(metricScale.domain()[0]);
     let accumulatedHeight = 0;
+    // The `Labels` component can't be used here due to stacking
+    // labels need to be computed per row, but then rendered at the end to avoid being hidden by stacked bar segments
+    const labels: JSX.Element[] = []
 
     return (
       <g transform={transform || defaultTransform}>
@@ -21,17 +26,32 @@ export const Bars: DiscreteAxialChart<string> = props => {
               width={categoricalScale.bandwidth()}
               height={height - metricScale(metric(row))}
               style={isFunction(style) ? style(row, i) : style}
-              key={i}
+              key={`bar-${i}`}
             />
           );
+          const label = (
+            <text
+              x={categoricalScale(categorical(row))! + bandWidth / 2}
+              y={metricScale(metric(row)) - accumulatedHeight}
+              dy={"-0.35em"}
+              style={verticalLabelStyle}
+              key={`label-${i}`}
+            >
+              {metric(row)}
+            </text>
+          )
+          labels.push(label)
           accumulatedHeight += height - metricScale(metric(row));
           return bar;
         })}
+        {displayLabels && labels}
       </g>
     );
   } else {
     let accumulatedWidth = 0;
-
+    // The `Labels` component can't be used here due to stacking
+    // labels need to be computed per row, but then rendered at the end to avoid being hidden by stacked bar segments
+    const labels: JSX.Element[] = []
     return (
       <g transform={transform || defaultTransform}>
         {data.mapRows((row, i) => {
@@ -42,12 +62,26 @@ export const Bars: DiscreteAxialChart<string> = props => {
               height={categoricalScale.bandwidth()}
               width={metricScale(metric(row))}
               style={isFunction(style) ? style(row, i) : style}
-              key={i}
+              key={`bar-${i}`}
             />
           );
+          const label = (
+            <text
+              x={metricScale(metric(row)) + accumulatedWidth}
+              y={categoricalScale(categorical(row))! + bandWidth / 2}
+              dx={4}
+              dy={"0.35em"}
+              style={baseLabelStyle}
+              key={`label=${i}`}
+            >
+              {metric(row)}
+            </text>
+          )
+          labels.push(label)
           accumulatedWidth += metricScale(metric(row));
           return bar;
         })}
+        {displayLabels && labels}
       </g>
     );
   }

--- a/packages/visualizations/src/Bars.tsx
+++ b/packages/visualizations/src/Bars.tsx
@@ -6,7 +6,7 @@ import { baseStyle as baseLabelStyle, verticalStyle as verticalLabelStyle } from
 
 export const Bars: DiscreteAxialChart<string> = props => {
   const defaultTransform = useChartTransform();
-  const { data, transform, metric, categorical, metricScale, categoricalScale, displayLabels, style } = props;
+  const { data, transform, metric, categorical, metricScale, categoricalScale, showLabels, style } = props;
   const bandWidth = categoricalScale.bandwidth();
 
   if (props.metricDirection === "vertical") {
@@ -44,7 +44,7 @@ export const Bars: DiscreteAxialChart<string> = props => {
           accumulatedHeight += height - metricScale(metric(row));
           return bar;
         })}
-        {displayLabels && labels}
+        {showLabels && labels}
       </g>
     );
   } else {
@@ -81,7 +81,7 @@ export const Bars: DiscreteAxialChart<string> = props => {
           accumulatedWidth += metricScale(metric(row));
           return bar;
         })}
-        {displayLabels && labels}
+        {showLabels && labels}
       </g>
     );
   }

--- a/packages/visualizations/src/Dots.tsx
+++ b/packages/visualizations/src/Dots.tsx
@@ -8,7 +8,7 @@ const radius = 3;
 
 export const Dots: DiscreteAxialChart<string> = props => {
   const defaultTransform = useChartTransform();
-  const { data, transform, metric, categorical, metricScale, categoricalScale, metricDirection, displayLabels, style } = props;
+  const { data, transform, metric, categorical, metricScale, categoricalScale, metricDirection, showLabels, style } = props;
 
   const bandWidth = categoricalScale.bandwidth();
 
@@ -38,7 +38,7 @@ export const Dots: DiscreteAxialChart<string> = props => {
           ))}
         </g>
     }
-    {displayLabels && <Labels
+    {showLabels && <Labels
       data={data}
       transform={transform}
       metric={metric}

--- a/packages/visualizations/src/Dots.tsx
+++ b/packages/visualizations/src/Dots.tsx
@@ -2,43 +2,51 @@ import React from "react";
 import { useChartTransform } from "./Chart";
 import { DiscreteAxialChart } from "./types";
 import { isFunction } from "./utils";
+import { Labels } from "./Labels";
 
 const radius = 3;
 
 export const Dots: DiscreteAxialChart<string> = props => {
   const defaultTransform = useChartTransform();
-  const { data, transform, metric, categorical, metricScale, categoricalScale, metricDirection, style } = props;
+  const { data, transform, metric, categorical, metricScale, categoricalScale, metricDirection, displayLabels, style } = props;
 
   const bandWidth = categoricalScale.bandwidth();
 
   // this doesn't make much sense for ScatterPlot, but this is temprorary solution for compatibility
-  if (metricDirection === "vertical") {
-    return (
-      <g transform={transform || defaultTransform}>
-        {data.mapRows((row, i) => (
-          <circle
-            cx={categoricalScale(categorical(row))! + bandWidth / 2}
-            cy={metricScale(metric(row))}
-            r={radius}
-            style={isFunction(style) ? style(row, i) : style}
-            key={i}
-          />
-        ))}
-      </g>
-    );
-  } else {
-    return (
-      <g transform={transform || defaultTransform}>
-        {data.mapRows((row, i) => (
-          <circle
-            cx={metricScale(metric(row))}
-            cy={categoricalScale(categorical(row))! + bandWidth / 2}
-            r={radius}
-            style={isFunction(style) ? style(row, i) : style}
-            key={i}
-          />
-        ))}
-      </g>
-    );
-  }
+  return <>
+    {metricDirection === "vertical"
+       ? <g transform={transform || defaultTransform}>
+          {data.mapRows((row, i) => (
+            <circle
+              cx={categoricalScale(categorical(row))! + bandWidth / 2}
+              cy={metricScale(metric(row))}
+              r={radius}
+              style={isFunction(style) ? style(row, i) : style}
+              key={i}
+            />
+          ))}
+        </g>
+        : <g transform={transform || defaultTransform}>
+          {data.mapRows((row, i) => (
+            <circle
+              cx={metricScale(metric(row))}
+              cy={categoricalScale(categorical(row))! + bandWidth / 2}
+              r={radius}
+              style={isFunction(style) ? style(row, i) : style}
+              key={i}
+            />
+          ))}
+        </g>
+    }
+    {displayLabels && <Labels
+      data={data}
+      transform={transform}
+      metric={metric}
+      categorical={categorical}
+      metricScale={metricScale}
+      categoricalScale={categoricalScale}
+      metricDirection={metricDirection}
+      style={{ transform: metricDirection === "vertical" ?`translate(0, -${radius}px)` : `translate(${radius}px, 0)` }}
+    />}
+  </>
 };

--- a/packages/visualizations/src/Labels.tsx
+++ b/packages/visualizations/src/Labels.tsx
@@ -4,12 +4,12 @@ import { DiscreteAxialChart } from "./types";
 import { isFunction } from "./utils";
 import theme from "./theme";
 
-const baseStyle: React.CSSProperties = {
+export const baseStyle: React.CSSProperties = {
   fontSize: theme.font.size.small,
-  color: theme.colors.axis.label
+  fill: theme.font.color,
 };
 
-const verticalStyle: React.CSSProperties = {
+export const verticalStyle: React.CSSProperties = {
   ...baseStyle,
   textAnchor: "middle"
 };
@@ -54,7 +54,7 @@ export const Labels: DiscreteAxialChart<string> = props => {
           <text
             x={metricScale(metric(row))}
             y={categoricalScale(categorical(row))! + bandWidth / 2}
-            dx={4}
+            dx={"0.35em"}
             dy={"0.35em"}
             style={{
               ...baseStyle,

--- a/packages/visualizations/src/Labels.tsx
+++ b/packages/visualizations/src/Labels.tsx
@@ -35,7 +35,7 @@ export const Labels: DiscreteAxialChart<string> = props => {
           <text
             x={categoricalScale(categorical(row))! + bandWidth / 2}
             y={metricScale(metric(row))}
-            dy={"-0.35em"}
+            dy="-0.35em"
             style={{
               ...verticalStyle,
               ...(isFunction(style) ? style(row, i) : style)
@@ -54,8 +54,8 @@ export const Labels: DiscreteAxialChart<string> = props => {
           <text
             x={metricScale(metric(row))}
             y={categoricalScale(categorical(row))! + bandWidth / 2}
-            dx={"0.35em"}
-            dy={"0.35em"}
+            dx="0.35em"
+            dy="0.35em"
             style={{
               ...baseStyle,
               ...(isFunction(style) ? style(row, i) : style)

--- a/packages/visualizations/src/Line.tsx
+++ b/packages/visualizations/src/Line.tsx
@@ -8,7 +8,7 @@ import { Labels } from "./Labels";
 export const Line: LinearAxialChart<string> = React.memo(props => {
   const defaultTransform = useChartTransform();
 
-  const { metricDirection, data, transform, metric, categorical, metricScale, categoricalScale, displayLabels, style } = props;
+  const { metricDirection, data, transform, metric, categorical, metricScale, categoricalScale, showLabels, style } = props;
 
   // The categorical scale must be a band scale for composability with bar charts.
   // Half of the tick width must be added to align with the ticks.
@@ -58,7 +58,7 @@ export const Line: LinearAxialChart<string> = React.memo(props => {
           }}
         />
       </g>
-      {displayLabels && <Labels
+      {showLabels && <Labels
         data={data}
         transform={transform}
         metric={metric}

--- a/packages/visualizations/src/Line.tsx
+++ b/packages/visualizations/src/Line.tsx
@@ -3,11 +3,12 @@ import React from "react";
 import { useChartTransform } from "./Chart";
 import { LinearAxialChart } from "./types";
 import { isFunction } from "./utils";
+import { Labels } from "./Labels";
 
 export const Line: LinearAxialChart<string> = React.memo(props => {
   const defaultTransform = useChartTransform();
 
-  const { metricDirection, data, transform, metric, categorical, metricScale, categoricalScale, style } = props;
+  const { metricDirection, data, transform, metric, categorical, metricScale, categoricalScale, displayLabels, style } = props;
 
   // The categorical scale must be a band scale for composability with bar charts.
   // Half of the tick width must be added to align with the ticks.
@@ -46,15 +47,26 @@ export const Line: LinearAxialChart<string> = React.memo(props => {
   const pathStyle = (isFunction(style) ? style(data.row(0), 0) : style) || {}
 
   return (
-    <g transform={transform || defaultTransform}>
-      <path
-        d={path}
-        style={{
-          fill: "none",
-          strokeLinecap: "round",
-          ...pathStyle
-        }}
-      />
-    </g>
+    <>
+      <g transform={transform || defaultTransform}>
+        <path
+          d={path}
+          style={{
+            fill: "none",
+            strokeLinecap: "round",
+            ...pathStyle
+          }}
+        />
+      </g>
+      {displayLabels && <Labels
+        data={data}
+        transform={transform}
+        metric={metric}
+        categorical={categorical}
+        metricScale={metricScale}
+        categoricalScale={categoricalScale}
+        metricDirection={metricDirection}
+      />}
+    </>
   );
 });

--- a/packages/visualizations/src/PieChart.tsx
+++ b/packages/visualizations/src/PieChart.tsx
@@ -10,7 +10,7 @@ interface PieChartProps<Name extends string> {
   height: number;
   data: IterableFrame<Name>;
   metric: ColumnCursor<Name>;
-  displayLabels: boolean;
+  showLabels: boolean;
   transform?: React.SVGAttributes<SVGRectElement>["transform"];
   style?:
     | React.SVGAttributes<SVGGElement>["style"]
@@ -20,7 +20,7 @@ interface PieChartProps<Name extends string> {
 export const PieChart = (props: PieChartProps<string>) => {
   const defaultTransform = useChartTransform();
 
-  const { data, width, height, metric, displayLabels, transform, style } = props;
+  const { data, width, height, metric, showLabels, transform, style } = props;
   const pieData = pie<RowCursor>().value(metric)(data.mapRows(row => row));
   const radius = Math.min(width, height) / 2;
   const segmentArc = arc<PieArcDatum<RowCursor>>().innerRadius(0).outerRadius(radius);
@@ -38,7 +38,7 @@ export const PieChart = (props: PieChartProps<string>) => {
                 d={segmentArc(datum) || ""}
                 style={isFunction(style) ? style(datum.data, i) : style}
               />
-              {displayLabels && <text
+              {showLabels && <text
                 x={labelPosition[0]}
                 y={labelPosition[1]}
                 style={{

--- a/packages/visualizations/src/PieChart.tsx
+++ b/packages/visualizations/src/PieChart.tsx
@@ -3,12 +3,14 @@ import { RowCursor, ColumnCursor, IterableFrame } from "@operational/frame";
 import { arc, pie, PieArcDatum } from "d3-shape";
 import { isFunction } from "./utils";
 import { useChartTransform } from "./Chart";
+import { verticalStyle as verticalLabelStyle } from "./Labels";
 
 interface PieChartProps<Name extends string> {
   width: number;
   height: number;
   data: IterableFrame<Name>;
   metric: ColumnCursor<Name>;
+  displayLabels: boolean;
   transform?: React.SVGAttributes<SVGRectElement>["transform"];
   style?:
     | React.SVGAttributes<SVGGElement>["style"]
@@ -18,21 +20,38 @@ interface PieChartProps<Name extends string> {
 export const PieChart = (props: PieChartProps<string>) => {
   const defaultTransform = useChartTransform();
 
-  const { data, width, height, metric, transform, style } = props;
-  const pieData = pie<RowCursor>().value(metric)(data.mapRows(row => row))
-  const segmentPath = (datum: PieArcDatum<RowCursor>) =>
-    arc<PieArcDatum<RowCursor>>().innerRadius(0).outerRadius(Math.min(width, height) / 2)(datum) || "";
+  const { data, width, height, metric, displayLabels, transform, style } = props;
+  const pieData = pie<RowCursor>().value(metric)(data.mapRows(row => row));
+  const radius = Math.min(width, height) / 2;
+  const segmentArc = arc<PieArcDatum<RowCursor>>().innerRadius(0).outerRadius(radius);
+  const segmentArcForLabel = arc<PieArcDatum<RowCursor>>().innerRadius(0.7 * radius).outerRadius(radius);
 
   return (
     <g transform={transform || defaultTransform}>
       <g transform={`translate(${width / 2},${height / 2})`}>
-        {pieData.map((datum, i) => (
-          <path
-            key={i}
-            d={segmentPath(datum)}
-            style={isFunction(style) ? style(datum.data, i) : style}
-          />
-        ))}
+        {pieData.map((datum, i) => {
+          const labelPosition = segmentArcForLabel.centroid(datum);
+          return (
+            <>
+              <path
+                key={`segment-${i}`}
+                d={segmentArc(datum) || ""}
+                style={isFunction(style) ? style(datum.data, i) : style}
+              />
+              {displayLabels && <text
+                x={labelPosition[0]}
+                y={labelPosition[1]}
+                style={{
+                  ...verticalLabelStyle,
+                  fill: "white",
+                }}
+                key={`label-${i}`}
+              >
+                {datum.value}
+              </text>}
+            </>
+          )
+        })}
       </g>
     </g>
   );

--- a/packages/visualizations/src/types.ts
+++ b/packages/visualizations/src/types.ts
@@ -8,6 +8,7 @@ export interface BaseAxialChartProps<Name extends string> {
   categorical: ColumnCursor<Name>;
   metricScale: ScaleLinear<any, any>;
   categoricalScale: ScaleBand<string>;
+  displayLabels?: boolean;
   transform?: React.SVGAttributes<SVGRectElement>["transform"];
   style?:
     | React.SVGAttributes<SVGGElement>["style"]

--- a/packages/visualizations/src/types.ts
+++ b/packages/visualizations/src/types.ts
@@ -8,7 +8,7 @@ export interface BaseAxialChartProps<Name extends string> {
   categorical: ColumnCursor<Name>;
   metricScale: ScaleLinear<any, any>;
   categoricalScale: ScaleBand<string>;
-  displayLabels?: boolean;
+  showLabels?: boolean;
   transform?: React.SVGAttributes<SVGRectElement>["transform"];
   style?:
     | React.SVGAttributes<SVGGElement>["style"]


### PR DESCRIPTION
In previous PR (#132) a labels component was added, with the intention of adding labels manually in the same way as all other renderers are implemented:

```
<Chart>
  <Bars ... />
  <Labels ... />
</Chart
```

This PR leaves that API intact, but also enables the display of labels through a `displayLabels` flag. This solves multiple problems:

- In the case of stacked bars or area charts, using the previous API did not take stacking into account, so the labels were in the wrong places.
- The `Labels` component only worked for axial charts, not for pie charts, so the `Pie Chart` would have needed a flag anyway - this ensures consistency across all renderers.
- For scatter plots, the labels are now automatically offset by the radius of the dots. Any other renderer-specific styling that may be required is now also easier.

![image](https://user-images.githubusercontent.com/14272822/64519678-e0fc6000-d2f4-11e9-9055-6a3e218c2280.png)
![image](https://user-images.githubusercontent.com/14272822/64519693-eb1e5e80-d2f4-11e9-86a0-c0b09dc8cd08.png)
