### PR TITLE
Fix labels for scatter plots

### DIFF
--- a/packages/visualizations-stories/src/vizualisations/5-scatter-plot.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/5-scatter-plot.stories.tsx
@@ -1,38 +1,47 @@
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { DataFrame } from "@operational/frame";
-import { Axis, Dots, Chart, ChartProps, Legend, useScale, ScaleType, useColorScale } from "@operational/visualizations";
+import {
+  Axis,
+  Dots,
+  Chart,
+  ChartProps,
+  Legend,
+  useScale,
+  ScaleType,
+  useColorScale
+} from "@operational/visualizations";
 
 const rawData = {
   columns: [
     {
       name: "Customer.Continent" as "Customer.Continent",
-      type: "string",
+      type: "string"
     },
     {
       name: "Customer.Country" as "Customer.Country",
-      type: "string",
+      type: "string"
     },
     {
       name: "Customer.City" as "Customer.City",
-      type: "string",
+      type: "string"
     },
     {
       name: "Customer.AgeGroup" as "Customer.AgeGroup",
-      type: "string",
+      type: "string"
     },
     {
       name: "Customer.Gender" as "Customer.Gender",
-      type: "string",
+      type: "string"
     },
     {
       name: "sales" as "sales",
-      type: "number",
+      type: "number"
     },
     {
       name: "revenue" as "revenue",
-      type: "number",
-    },
+      type: "number"
+    }
   ],
   rows: [
     ["Europe", "Germany", "Berlin", "<50", "Female", 101, 10.2],
@@ -41,8 +50,8 @@ const rawData = {
     ["Europe", "UK", "London", "<50", "Female", 401, 40.2],
     ["Europe", "UK", "Edinburgh", "<50", "Female", 501, 50.2],
     ["North America", "USA", "New York", "<50", "Female", 801, 80.2],
-    ["North America", "Canada", "Toronto", "<50", "Female", 801, 80.2],
-  ],
+    ["North America", "Canada", "Toronto", "<50", "Female", 801, 80.2]
+  ]
 };
 
 const frame = new DataFrame(rawData.columns, rawData.rows);
@@ -71,7 +80,7 @@ const ScatterPlot = <Name extends string>({
   y,
   xType,
   yType,
-  colorBy,
+  colorBy
 }: ScatterPlotProps<Name>) => {
   const xCursor = data.getCursor(x);
   const yCursor = data.getCursor(y);
@@ -80,13 +89,13 @@ const ScatterPlot = <Name extends string>({
     type: xType,
     frame: data,
     column: xCursor,
-    range: [0, width],
+    range: [0, width]
   });
   const yScale = useScale({
     type: yType,
     frame: data,
     column: yCursor,
-    range: [height, 0],
+    range: [height, 0]
   });
 
   const colorCursors = (colorBy || []).map(c => data.getCursor(c));
@@ -95,13 +104,19 @@ const ScatterPlot = <Name extends string>({
   return (
     <div style={{ display: "inline-block" }}>
       <Legend data={data} colorScale={colorScale} cursors={colorCursors} />
-      <Chart width={width} height={height} margin={margin} style={{ background: "#fff" }}>
+      <Chart
+        width={width}
+        height={height}
+        margin={margin}
+        style={{ background: "#fff" }}
+      >
         <Dots
           data={data}
           x={xCursor}
           y={yCursor}
           xScale={xScale}
           yScale={yScale}
+          showLabels={true}
           style={row => ({ fill: colorScale(row) })}
         />
         <Axis scale={xScale} position="bottom" />
@@ -114,7 +129,7 @@ const ScatterPlot = <Name extends string>({
 storiesOf("@operational/visualizations/5. Scatter plot", module)
   .add("band x linear", () => {
     // number of pixels picked manually to make sure that YAxis fits on the screen
-    const magicMargin = [5, 10, 20, 60] as ChartProps["margin"];
+    const magicMargin = [20, 10, 20, 60] as ChartProps["margin"];
     return (
       <ScatterPlot
         x="Customer.City"

--- a/packages/visualizations/src/Dots.tsx
+++ b/packages/visualizations/src/Dots.tsx
@@ -4,7 +4,7 @@ import { isFunction } from "./utils";
 import { IterableFrame, ColumnCursor, RowCursor } from "@operational/frame";
 import { ScaleLinear, ScaleBand } from "d3-scale";
 import { isScaleBand } from "./scale";
-// import { Labels } from "./Labels";
+import { Labels } from "./Labels";
 
 const radius = 3;
 
@@ -17,15 +17,21 @@ export interface DotsProps<Name extends string> {
   transform?: React.SVGAttributes<SVGRectElement>["transform"];
   style?:
     | React.SVGAttributes<SVGGElement>["style"]
-    | ((row: RowCursor, i: number) => React.SVGAttributes<SVGGElement>["style"]);
+    | ((
+        row: RowCursor,
+        i: number
+      ) => React.SVGAttributes<SVGGElement>["style"]);
   showLabels?: boolean;
 }
 
 export const Dots = <Name extends string>(props: DotsProps<Name>) => {
   const defaultTransform = useChartTransform();
-  const { data, transform, x, y, xScale, yScale, style /*, showLabels*/ } = props;
+  const { data, transform, x, y, xScale, yScale, style, showLabels } = props;
   const xBandWidth = isScaleBand(xScale) ? xScale.bandwidth() : 0;
   const yBandWidth = isScaleBand(yScale) ? yScale.bandwidth() : 0;
+  // Temporary solution until Labels and other renderers have been refactored to take x and y parameters
+  // rather than categorical and metric.
+  const isVertical = isScaleBand(xScale);
   return (
     <>
       <g transform={transform || defaultTransform}>
@@ -39,20 +45,18 @@ export const Dots = <Name extends string>(props: DotsProps<Name>) => {
           />
         ))}
       </g>
-      {/* {showLabels && (
+      {showLabels && (
         <Labels
           data={data}
           transform={transform}
-          metric={metric}
-          categorical={categorical}
-          metricScale={metricScale}
-          categoricalScale={categoricalScale}
-          metricDirection={metricDirection}
-          style={{
-            transform: metricDirection === "vertical" ? `translate(0, -${radius}px)` : `translate(${radius}px, 0)`,
-          }}
+          metric={isVertical ? y : x}
+          categorical={isVertical ? x : y}
+          metricScale={(isVertical ? yScale : xScale) as ScaleLinear<any, any>}
+          categoricalScale={(isVertical ? xScale : yScale) as ScaleBand<string>}
+          metricDirection={isVertical ? "vertical" : "horizontal"}
+          style={{ transform: `translate(0, -${radius}px)` }}
         />
-      )} */}
+      )}
     </>
   );
 };


### PR DESCRIPTION
Re-implement labels for scatter plots. 
This is a temporary fix, until the `Labels` component (and other renderers) have been refactored to take `x` and `y` parameters instead of `metric` and `categorical`.