### PR TITLE
feat(Visualizations): Add number formatting

### DIFF
--- a/packages/visualizations-stories/src/vizualisations/1-bar-chart.stories.tsx
+++ b/packages/visualizations-stories/src/vizualisations/1-bar-chart.stories.tsx
@@ -46,13 +46,13 @@ const rawData = {
     },
   ],
   rows: [
-    ["Europe", "Germany", "Berlin", "<50", "Female", 101, 10.2],
-    ["Europe", "Germany", "Dresden", "<50", "Female", 201, 20.2],
-    ["Europe", "Germany", "Hamburg", "<50", "Female", 301, 30.2],
-    ["Europe", "UK", "London", "<50", "Female", 401, 40.2],
-    ["Europe", "UK", "Edinburgh", "<50", "Female", 501, 50.2],
-    ["North America", "USA", "New York", "<50", "Female", 801, 80.2],
-    ["North America", "Canada", "Toronto", "<50", "Female", 801, 80.2],
+    ["Europe", "Germany", "Berlin", "<50", "Female", 1001, 10.2],
+    ["Europe", "Germany", "Dresden", "<50", "Female", 2001, 20.2],
+    ["Europe", "Germany", "Hamburg", "<50", "Female", 3001, 30.2],
+    ["Europe", "UK", "London", "<50", "Female", 4001, 40.2],
+    ["Europe", "UK", "Edinburgh", "<50", "Female", 5001, 50.2],
+    ["North America", "USA", "New York", "<50", "Female", 8001, 80.2],
+    ["North America", "Canada", "Toronto", "<50", "Female", 8001, 80.2],
   ],
 };
 

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -21,7 +21,9 @@
     "prepare": "tsc"
   },
   "dependencies": {
+    "@types/d3-format": "^1.3.1",
     "d3-axis": "^1.0.12",
+    "d3-format": "^1.4.1",
     "d3-scale": "^3.0.0",
     "d3-selection": "^1.3.2",
     "d3-shape": "^1.3.5"

--- a/packages/visualizations/src/Area.tsx
+++ b/packages/visualizations/src/Area.tsx
@@ -2,7 +2,7 @@ import { area, line } from "d3-shape";
 import React from "react";
 import { useChartTransform } from "./Chart";
 import { LinearAxialChart } from "./types";
-import { isFunction } from "./utils";
+import { isFunction, numberFormatter } from "./utils";
 import { baseStyle as baseLabelStyle, verticalStyle as verticalLabelStyle } from "./Labels";
 import { ColumnCursor } from "@operational/frame";
 import { isScaleBand, isScaleContinuous } from "./scale";
@@ -139,7 +139,7 @@ export const Area: LinearAxialChart<string> = ({ data, transform, x, y, xScale, 
                 dy="0.35em"
                 style={baseLabelStyle}
               >
-                {isDefined(d.m1) && isDefined(d.m0) ? d.m1 - d.m0 : ""}
+                {isDefined(d.m1) && isDefined(d.m0) ? numberFormatter(d.m1 - d.m0) : ""}
               </text>
             ),
           ),

--- a/packages/visualizations/src/Axis.tsx
+++ b/packages/visualizations/src/Axis.tsx
@@ -16,7 +16,7 @@ export interface AxisProps {
   maxNumberOfTicks?: number;
 }
 
-export const Axis: React.FC<AxisProps> = React.memo(({ scale, transform, position, maxNumberOfTicks = 10 }) => {
+export const Axis: React.FC<AxisProps> = React.memo(({ scale, transform, position, maxNumberOfTicks }) => {
   const defaultTransform = useAxisTransform(position!);
   const ref = useRef<SVGGElement>(null);
   useEffect(() => {
@@ -24,7 +24,7 @@ export const Axis: React.FC<AxisProps> = React.memo(({ scale, transform, positio
       const nTicks = (isScaleContinuous(scale) ? scale.ticks() : scale.domain()).length;
       const formatter = isScaleContinuous(scale) ? d3Format("~s") : (d: any) => d;
       const tickFormat =
-        nTicks > maxNumberOfTicks
+        maxNumberOfTicks !== undefined && nTicks > maxNumberOfTicks
           ? (d: any, i: number) => (i % maxNumberOfTicks === 0 ? formatter(d) : null)
           : formatter;
 

--- a/packages/visualizations/src/Axis.tsx
+++ b/packages/visualizations/src/Axis.tsx
@@ -1,4 +1,5 @@
 import { axisBottom, axisLeft, axisTop, axisRight } from "d3-axis";
+import { format as d3Format } from "d3-format";
 import { ScaleBand, ScaleLinear } from "d3-scale";
 import { select } from "d3-selection";
 import React, { useEffect, useRef } from "react";
@@ -20,9 +21,13 @@ export const Axis: React.FC<AxisProps> = React.memo(({ scale, transform, positio
   const ref = useRef<SVGGElement>(null);
   useEffect(() => {
     if (ref.current) {
-      const ticks = (isScaleContinuous(scale) ? scale.ticks() : scale.domain()).length;
+      const nTicks = (isScaleContinuous(scale) ? scale.ticks() : scale.domain()).length;
+      const formatter = isScaleContinuous(scale) ? d3Format("~s") : (d: any) => d;
       const tickFormat =
-        ticks > maxNumberOfTicks ? (d: any, i: number) => (i % maxNumberOfTicks === 0 ? d : null) : (d: any) => d;
+        nTicks > maxNumberOfTicks
+          ? (d: any, i: number) => (i % maxNumberOfTicks === 0 ? formatter(d) : null)
+          : formatter;
+
       switch (position) {
         case "bottom":
           select(ref.current).call(axisBottom(scale).tickFormat(tickFormat));

--- a/packages/visualizations/src/Bars.tsx
+++ b/packages/visualizations/src/Bars.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useChartTransform } from "./Chart";
 import { DiscreteAxialChart } from "./types";
-import { isFunction } from "./utils";
+import { isFunction, numberFormatter } from "./utils";
 import { baseStyle as baseLabelStyle, verticalStyle as verticalLabelStyle } from "./Labels";
 import { isScaleBand, isScaleContinuous } from "./scale";
 
@@ -37,7 +37,7 @@ export const Bars: DiscreteAxialChart<string> = ({ data, transform, x, y, xScale
               style={verticalLabelStyle}
               key={`label-${i}`}
             >
-              {y(row)}
+              {numberFormatter(y(row))}
             </text>
           );
           labels.push(label);
@@ -75,7 +75,7 @@ export const Bars: DiscreteAxialChart<string> = ({ data, transform, x, y, xScale
               style={baseLabelStyle}
               key={`label-${i}`}
             >
-              {x(row)}
+              {numberFormatter(x(row))}
             </text>
           );
           labels.push(label);

--- a/packages/visualizations/src/Labels.tsx
+++ b/packages/visualizations/src/Labels.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useChartTransform } from "./Chart";
 import { DiscreteAxialChart } from "./types";
-import { isFunction } from "./utils";
+import { isFunction, numberFormatter } from "./utils";
 import theme from "./theme";
 import { isScaleBand, isScaleContinuous } from "./scale";
 
@@ -17,7 +17,6 @@ export const verticalStyle: React.CSSProperties = {
 
 export const Labels: DiscreteAxialChart<string> = ({ data, transform, x, y, xScale, yScale, style }) => {
   const defaultTransform = useChartTransform();
-
   if (isScaleBand(xScale) && isScaleContinuous(yScale)) {
     const bandWidth = xScale.bandwidth();
     return (
@@ -33,7 +32,7 @@ export const Labels: DiscreteAxialChart<string> = ({ data, transform, x, y, xSca
             }}
             key={i}
           >
-            {y(row)}
+            {numberFormatter(y(row))}
           </text>
         ))}
       </g>
@@ -54,7 +53,7 @@ export const Labels: DiscreteAxialChart<string> = ({ data, transform, x, y, xSca
             }}
             key={i}
           >
-            {x(row)}
+            {numberFormatter(x(row))}
           </text>
         ))}
       </g>

--- a/packages/visualizations/src/PieChart.tsx
+++ b/packages/visualizations/src/PieChart.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { RowCursor, ColumnCursor, IterableFrame } from "@operational/frame";
 import { arc, pie, PieArcDatum } from "d3-shape";
-import { isFunction } from "./utils";
+import { isFunction, numberFormatter } from "./utils";
 import { useChartTransform } from "./Chart";
 import { verticalStyle as verticalLabelStyle } from "./Labels";
 
@@ -52,7 +52,7 @@ export const PieChart = (props: PieChartProps<string>) => {
                   }}
                   key={`label-${i}`}
                 >
-                  {datum.value}
+                  {numberFormatter(datum.value)}
                 </text>
               )}
             </>

--- a/packages/visualizations/src/__tests__/utils.test.ts
+++ b/packages/visualizations/src/__tests__/utils.test.ts
@@ -1,0 +1,23 @@
+import { numberFormatter, removeTrailingZeros } from "../utils";
+
+describe("numberFormatter()", () => {
+  it("formats numbers correctly", () => {
+    expect(numberFormatter(123456)).toEqual("123,456");
+    expect(numberFormatter(123456.789)).toEqual("123,457");
+    expect(numberFormatter(12.3456)).toEqual("12.3");
+    expect(numberFormatter(0)).toEqual("0");
+    expect(numberFormatter(0.0)).toEqual("0");
+    expect(numberFormatter(-12.3456)).toEqual("-12.3");
+    expect(numberFormatter(1.23456)).toEqual("1.23");
+    expect(numberFormatter(5)).toEqual("5");
+    expect(numberFormatter(0.123456)).toEqual("0.123");
+  });
+});
+
+describe("removeTrailingZeros()", () => {
+  it("removes trailing zeros", () => {
+    expect(removeTrailingZeros("123.45000")).toEqual("123.45");
+    expect(removeTrailingZeros("123.00000")).toEqual("123");
+    expect(removeTrailingZeros("12345000")).toEqual("12345");
+  });
+});

--- a/packages/visualizations/src/theme.ts
+++ b/packages/visualizations/src/theme.ts
@@ -59,7 +59,7 @@ const font = {
     /** 12 */
     default: 12,
     /** 11 */
-    small: 11,
+    small: 10,
   },
   weight: {
     /** 400 */

--- a/packages/visualizations/src/utils.ts
+++ b/packages/visualizations/src/utils.ts
@@ -1,3 +1,7 @@
+import { format as d3Format } from "d3-format";
+
 export const isFunction = (x: any): x is Function => x instanceof Function;
 
 export const joinArrayAsString = (array: any[]) => (array || []).join(" / ");
+
+export const numberFormatter = d3Format(",");

--- a/packages/visualizations/src/utils.ts
+++ b/packages/visualizations/src/utils.ts
@@ -5,13 +5,13 @@ export const isFunction = (x: any): x is Function => x instanceof Function;
 export const joinArrayAsString = (array: any[]) => (array || []).join(" / ");
 
 export const numberFormatter = (val: number) => {
-  if (val > 100) {
+  if (Math.abs(val) > 100) {
     return d3Format(",.0f");
   }
-  if (val > 10) {
+  if (Math.abs(val) > 10) {
     return d3Format(",.1f");
   }
-  if (val > 0) {
+  if (Math.abs(val) > 0) {
     return d3Format(",.2f");
   }
   return d3Format(".,3f");

--- a/packages/visualizations/src/utils.ts
+++ b/packages/visualizations/src/utils.ts
@@ -4,4 +4,15 @@ export const isFunction = (x: any): x is Function => x instanceof Function;
 
 export const joinArrayAsString = (array: any[]) => (array || []).join(" / ");
 
-export const numberFormatter = d3Format(",.2f");
+export const numberFormatter = (val: number) => {
+  if (val > 100) {
+    return d3Format(",.0f");
+  }
+  if (val > 10) {
+    return d3Format(",.1f");
+  }
+  if (val > 0) {
+    return d3Format(",.2f");
+  }
+  return d3Format(".,3f");
+};

--- a/packages/visualizations/src/utils.ts
+++ b/packages/visualizations/src/utils.ts
@@ -4,13 +4,13 @@ export const isFunction = (x: any): x is Function => x instanceof Function;
 
 export const joinArrayAsString = (array: any[]) => (array || []).join(" / ");
 
-const removeTrailingZeros = (val: string) => {
+export const removeTrailingZeros = (val: string) => {
   return val.replace(/0*$/g, "").replace(/\.$/, "");
 };
 
 export const numberFormatter = (val: number) => {
   if (Math.abs(val) > 100) {
-    return removeTrailingZeros(d3Format(",.0f")(val));
+    return d3Format(",.0f")(val);
   }
   if (Math.abs(val) > 10) {
     return removeTrailingZeros(d3Format(",.1f")(val));

--- a/packages/visualizations/src/utils.ts
+++ b/packages/visualizations/src/utils.ts
@@ -4,15 +4,19 @@ export const isFunction = (x: any): x is Function => x instanceof Function;
 
 export const joinArrayAsString = (array: any[]) => (array || []).join(" / ");
 
+const removeTrailingZeros = (val: string) => {
+  return val.replace(/0*$/g, "").replace(/\.$/, "");
+};
+
 export const numberFormatter = (val: number) => {
   if (Math.abs(val) > 100) {
-    return d3Format(",.0f");
+    return removeTrailingZeros(d3Format(",.0f")(val));
   }
   if (Math.abs(val) > 10) {
-    return d3Format(",.1f");
+    return removeTrailingZeros(d3Format(",.1f")(val));
   }
-  if (Math.abs(val) > 0) {
-    return d3Format(",.2f");
+  if (Math.abs(val) > 1) {
+    return removeTrailingZeros(d3Format(",.2f")(val));
   }
-  return d3Format(".,3f");
+  return removeTrailingZeros(d3Format(",.3f")(val));
 };

--- a/packages/visualizations/src/utils.ts
+++ b/packages/visualizations/src/utils.ts
@@ -4,4 +4,4 @@ export const isFunction = (x: any): x is Function => x instanceof Function;
 
 export const joinArrayAsString = (array: any[]) => (array || []).join(" / ");
 
-export const numberFormatter = d3Format(",");
+export const numberFormatter = d3Format(",.2f");

--- a/yarn.lock
+++ b/yarn.lock
@@ -3006,6 +3006,11 @@
   dependencies:
     "@types/d3-selection" "*"
 
+"@types/d3-format@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-1.3.1.tgz#35bf88264bd6bcda39251165bb827f67879c4384"
+  integrity sha512-KAWvReOKMDreaAwOjdfQMm0HjcUMlQG47GwqdVKgmm20vTd2pucj0a70c3gUSHrnsmo6H2AMrkBsZU2UhJLq8A==
+
 "@types/d3-path@*":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-1.0.8.tgz#48e6945a8ff43ee0a1ce85c8cfa2337de85c7c79"
@@ -5994,6 +5999,11 @@ d3-format@1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.3.2.tgz#6a96b5e31bcb98122a30863f7d92365c00603562"
   integrity sha512-Z18Dprj96ExragQ0DeGi+SYPQ7pPfRMtUXtsg/ChVIKNBCzjO8XYJvRTC1usblx52lqge56V5ect+frYTQc8WQ==
+
+d3-format@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.1.tgz#c45f74b17c5a290c072a4ba7039dd19662cd5ce6"
+  integrity sha512-TUswGe6hfguUX1CtKxyG2nymO+1lyThbkS1ifLX0Sr+dOQtAD5gkrffpHnx+yHNKUZ0Bmg5T4AjUQwugPDrm0g==
 
 d3-interpolate@1:
   version "1.3.2"


### PR DESCRIPTION
Basic number formatting for axes and measure labels.

![image](https://user-images.githubusercontent.com/14272822/65127834-9c5d7c80-d9f8-11e9-9dbb-4a2e9b1e18da.png)

Axis ticks are truncated and an appropriate suffix added. Measure labels are not truncated and have commas added.